### PR TITLE
chore: replaced `v2/flows` with `v2/stored_flows`

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -19,37 +19,6 @@ class ErrorBase(Exception):
         return f"EVC {self.evc_id} {self.message}"
 
 
-class EvcAlreadyHasINT(ErrorBase):
-    """Exception in case the EVC already has INT/telemetry enabled. That's a warning."""
-
-    def __init__(self, evc_id, message="already has INT-enabled."):
-        super().__init__(evc_id, message)
-
-
-class EvcDoesNotExist(ErrorBase):
-    """Exception in case the EVC provided doesn't exist.
-    That's a warning."""
-
-    def __init__(self, evc_id, message="does not exist."):
-        super().__init__(evc_id, message)
-
-
-class NotPossibleToEnableTelemetry(ErrorBase):
-    """Exception in case it is not possible to enable telemetry.
-    That's an error. Maybe it requires some rollback treatment."""
-
-    def __init__(self, evc_id, message="error enabling telemetry. Check logs."):
-        super().__init__(evc_id, message)
-
-
-class NotPossibleToDisableTelemetry(ErrorBase):
-    """Exception in case it is not possible to disable telemetry.
-    That's an error. Maybe it requires some rollback treatment."""
-
-    def __init__(self, evc_id, message="error disabling telemetry. Check logs."):
-        super().__init__(evc_id, message)
-
-
 class NoProxyPortsAvailable(ErrorBase):
     """Exception in case an UNI doesn't have a proxy port configured or operational.
     That's a warning."""
@@ -70,13 +39,5 @@ class FlowsNotFound(ErrorBase):
     """Exception in case the EVC's flows are not there. Used for testing and debugging.
     That's an warning. Maybe it requires some investigation."""
 
-    def __init__(self, evc_id, message="Flow not found. Kytos still loading?"):
-        super().__init__(evc_id, message)
-
-
-class UnsupportedFlow(ErrorBase):
-    """Used for testing and debugging. Make sure the flows' retrieved are properly
-    formed."""
-
-    def __init__(self, evc_id, message="Unsupported Flow found."):
+    def __init__(self, evc_id, message="Flow not found."):
         super().__init__(evc_id, message)

--- a/kytos_api_helper.py
+++ b/kytos_api_helper.py
@@ -106,11 +106,6 @@ def set_telemetry_metadata_false(evc_id):
     return kytos_api(post=True, mef_eline=True, evc_id=evc_id, metadata=True, data=data)
 
 
-def get_topology_interfaces():
-    """Get list of interfaces"""
-    return kytos_api(get=True, topology=True, data="interfaces")
-
-
 def kytos_get_flows(switch):
     """Get flows from Flow Manager"""
     return kytos_api(get=True, flow_manager=True, switch=switch)

--- a/kytos_api_helper.py
+++ b/kytos_api_helper.py
@@ -5,10 +5,11 @@ other kytos napps' APIs """
 import datetime
 
 import httpx
+from napps.kytos.telemetry_int import settings
 
 from kytos.core import log
 
-from .settings import flow_manager_api, mef_eline_api, topology_api
+from .settings import flow_manager_api, mef_eline_api
 
 # pylint: disable=fixme,too-many-arguments,no-else-return
 
@@ -17,8 +18,6 @@ def kytos_api(
     get=False,
     put=False,
     post=False,
-    delete=False,
-    topology=False,
     mef_eline=False,
     evc_id=None,
     flow_manager=False,
@@ -29,16 +28,10 @@ def kytos_api(
     """Main function to handle requests to Kytos API."""
 
     # TODO: add support for batch, temporizer, retries
-
-    kytos_api_url = (
-        topology_api
-        if topology
-        else flow_manager_api
-        if flow_manager
-        else mef_eline_api
-        if mef_eline
-        else ""
-    )
+    if flow_manager_api:
+        kytos_api_url = flow_manager_api
+    if mef_eline:
+        kytos_api_url = mef_eline_api
 
     headers = {"Content-Type": "application/json"}
 
@@ -53,7 +46,7 @@ def kytos_api(
 
         elif post:
             if mef_eline and metadata:
-                url = f"{kytos_api_url}/{evc_id}/metadata"
+                url = f"{kytos_api_url}/evc/{evc_id}/metadata"
                 response = httpx.post(url, headers=headers, json=data, timeout=10)
                 return response.status_code == 201
 
@@ -62,35 +55,65 @@ def kytos_api(
                 response = httpx.post(url, headers=headers, json=data, timeout=10)
                 return response.status_code == 202
 
-        elif delete:
-            if flow_manager:
-                url = f"{kytos_api_url}/{switch}"
-                response = httpx.request(
-                    "DELETE", url, headers=headers, json=data, timeout=10
-                )
-                return response.status_code == 202
-
     except httpx.RequestError as http_err:
         log.error(f"HTTP error occurred: {http_err}")
 
     return False
 
 
-def get_evcs():
-    """Get list of EVCs"""
-    return kytos_api(get=True, mef_eline=True)
+def get_evcs(archived="false") -> dict:
+    """Get EVCs."""
+    try:
+        response = httpx.get(f"{settings.mef_eline_api}/evc/?archived={archived}")
+        response.raise_for_status()
+        return response.json()
+    except httpx.HTTPStatusError as exc:
+        log.error(f"response: {response.text} for {str(exc)}")
+        return {}
+
+
+def get_evc(evc_id: str) -> dict:
+    """Get EVC."""
+    try:
+        response = httpx.get(f"{settings.mef_eline_api}/evc/{evc_id}")
+        if response.status_code == 404:
+            return {}
+
+        response.raise_for_status()
+        data = response.json()
+        return {data["id"]: data}
+    except httpx.HTTPStatusError as exc:
+        log.error(f"response: {response.text} for {str(exc)}")
+        return {}
+
+
+def get_evc_flows(cookie: int, *dpid: str) -> dict:
+    """Get EVC's flows given a range of cookies."""
+    endpoint = (
+        f"stored_flows?cookie_range={cookie}&cookie_range={cookie}"
+        "&state=installed&state=pending"
+    )
+    if dpid:
+        dpid_query_args = [f"&dpid={val}" for val in dpid]
+        endpoint = f"{endpoint}{''.join(dpid_query_args)}"
+    response = httpx.get(f"{settings.flow_manager_api}/{endpoint}")
+    try:
+        response.raise_for_status()
+        return response.json()
+    except httpx.HTTPStatusError as exc:
+        log.error(f"response: {response.text} for {str(exc)}")
+        return {}
 
 
 def set_telemetry_metadata_true(evc_id, direction):
     """Set telemetry enabled metadata item to true"""
     data = {
         "telemetry": {
-            "enabled": "true",
+            "enabled": True,
             "direction": direction,
-            "timestamp": datetime.datetime.now().strftime("%m/%d/%YT%H:%M:%SZ"),
+            "timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
         }
     }
-    # TODO: add timestamp
     return kytos_api(post=True, mef_eline=True, evc_id=evc_id, metadata=True, data=data)
 
 
@@ -98,22 +121,12 @@ def set_telemetry_metadata_false(evc_id):
     """Set telemetry enabled metadata item to false"""
     data = {
         "telemetry": {
-            "enabled": "false",
-            "timestamp": datetime.datetime.now().strftime("%m/%d/%YT%H:%M:%SZ"),
+            "enabled": False,
+            "timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
         }
     }
 
     return kytos_api(post=True, mef_eline=True, evc_id=evc_id, metadata=True, data=data)
-
-
-def kytos_get_flows(switch):
-    """Get flows from Flow Manager"""
-    return kytos_api(get=True, flow_manager=True, switch=switch)
-
-
-def kytos_delete_flows(switch, data):
-    """Delete flows on Flow Manager"""
-    return kytos_api(delete=True, flow_manager=True, switch=switch, data=data)
 
 
 def kytos_push_flows(switch, data):

--- a/proxy_port.py
+++ b/proxy_port.py
@@ -1,81 +1,39 @@
 """ This class helps to handle multi-home physical loops (two ports). """
 
+from typing import Optional
 
-from .kytos_api_helper import get_topology_interfaces
 
-
-def get_kytos_interface(switch, interface):
-    """Get the Kytos Interface as dict. Useful for multiple functions."""
-
-    kytos_interfaces = get_topology_interfaces()["interfaces"]
-    for kytos_interface in kytos_interfaces.values():
-        if switch == kytos_interface["switch"]:
-            if interface == kytos_interface["port_number"]:
-                return kytos_interface
-    return None
+from kytos.core.controller import Controller
+from kytos.core.interface import Interface
+from kytos.core.common import EntityStatus
 
 
 class ProxyPort:
     """This class helps to handle multi-home physical loops (two ports)."""
 
-    def __init__(self, switch, proxy_port):
-        self.switch = switch
-        self.source = None
-        self.destination = None
-        self.process(proxy_port)
+    def __init__(self, controller: Controller, source: Interface):
+        self.controller = controller
+        self.source = source
 
-    def get_interface(self, interface):
-        """Retrieve the interface from Kytos"""
-        return get_kytos_interface(self.switch, interface)
-
-    @staticmethod
-    def is_operational(interface):
-        """Test if interface is enabled and active"""
-        if interface and interface["enabled"] and interface["active"]:
-            return True
-        return False
-
-    @staticmethod
-    def is_loop(interface):
-        """Confirm whether this interface is looped"""
+    @property
+    def destination(self) -> Optional[Interface]:
+        """Destination interface of the loop."""
         if (
-            "looped" in interface["metadata"]
-            and "port_numbers" in interface["metadata"]["looped"]
+            self.source.status != EntityStatus.UP
+            or "looped" not in self.source.metadata
+            or "port_numbers" not in self.source.metadata["looped"]
+            or not self.source.metadata["looped"]["port_numbers"]
+            or len(self.source.metadata["looped"]["port_numbers"]) < 2
         ):
-            return True
-        return False
-
-    def get_destination(self, interface):
-        """In case it is a multi-homed looped, get info of the other port
-        in the loop."""
-        if self.source != interface:
-            kytos_interface = self.get_interface(interface=interface)
-            if self.is_operational(kytos_interface):
-                return interface
             return None
 
-        return self.source
-
-    def process(self, proxy_port) -> None:
-        """Process the proxy_port metadata. Basically, it checks if it is a single
-        home or dual home physical loop and in either case, test if the interfaces
-        are operational.
-        """
-
-        kytos_interface = self.get_interface(interface=proxy_port)
-
-        if not self.is_operational(kytos_interface) or not self.is_loop(
-            kytos_interface
-        ):
-            return
-
-        self.source = kytos_interface["metadata"]["looped"]["port_numbers"][0]
-        self.destination = self.get_destination(
-            kytos_interface["metadata"]["looped"]["port_numbers"][1]
+        destination = self.source.get_interface_by_port_no(
+            self.source.metadata["looped"]["port_numbers"][1]
         )
+        if not destination or destination.status != EntityStatus.UP:
+            return None
+        return destination
 
-    def is_ready(self) -> bool:
+    def is_ready(self) -> Optional[bool]:
         """Make sure this class has all it needs"""
-        if self.source and self.destination:
-            return True
-        return False
+        return self.source and self.destination

--- a/proxy_port.py
+++ b/proxy_port.py
@@ -2,10 +2,9 @@
 
 from typing import Optional
 
-
+from kytos.core.common import EntityStatus
 from kytos.core.controller import Controller
 from kytos.core.interface import Interface
-from kytos.core.common import EntityStatus
 
 
 class ProxyPort:
@@ -27,7 +26,7 @@ class ProxyPort:
         ):
             return None
 
-        destination = self.source.get_interface_by_port_no(
+        destination = self.source.switch.get_interface_by_port_no(
             self.source.metadata["looped"]["port_numbers"][1]
         )
         if not destination or destination.status != EntityStatus.UP:

--- a/settings.py
+++ b/settings.py
@@ -1,13 +1,10 @@
 """Module with the Constants used in the amlight/telemetry."""
 
-NAPP_NAME = "Telemetry Napp"
-KYTOS_API = "http://0.0.0.0:8181/api/"
-mef_eline_api = KYTOS_API + "kytos/mef_eline/v2/evc/"
-topology_api = KYTOS_API + "kytos/topology/v3/"
-flow_manager_api = KYTOS_API + "kytos/flow_manager/v2/flows/"
-REST_VERSION = "v1"
-COOKIE_PREFIX = "0xa8"
-COOKIE_MASK = 18446744073709551615
+KYTOS_API = "http://0.0.0.0:8181/api"
+mef_eline_api = f"{KYTOS_API}/kytos/mef_eline/v2"
+flow_manager_api = f"{KYTOS_API}/kytos/flow_manager/v2"
+COOKIE_PREFIX = 0xA8
+MEF_COOKIE_PREFIX = 0xAA
 INT_TABLE = 2
 IPv4 = 2048
 TCP = 6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,429 @@
+"""Conftest."""
+import json
+import pytest
+
+
+@pytest.fixture
+def evcs_data() -> dict:
+    """evcs_data."""
+    data = """
+{
+    "3766c105686749": {
+        "active": true,
+        "archived": false,
+        "backup_path": [],
+        "bandwidth": 0,
+        "circuit_scheduler": [],
+        "current_path": [],
+        "dynamic_backup_path": true,
+        "enabled": true,
+        "failover_path": [],
+        "id": "3766c105686749",
+        "metadata": {},
+        "name": "evpl",
+        "primary_path": [],
+        "service_level": 6,
+        "uni_a": {
+            "tag": {
+                "tag_type": 1,
+                "value": 200
+            },
+            "interface_id": "00:00:00:00:00:00:00:01:1"
+        },
+        "uni_z": {
+            "tag": {
+                "tag_type": 1,
+                "value": 200
+            },
+            "interface_id": "00:00:00:00:00:00:00:01:2"
+        },
+        "sb_priority": null,
+        "execution_rounds": 0,
+        "owner": null,
+        "queue_id": null,
+        "primary_constraints": {},
+        "secondary_constraints": {},
+        "primary_links": [],
+        "backup_links": [],
+        "start_date": "2023-07-28T18:21:15",
+        "creation_time": "2023-07-28T18:21:15",
+        "request_time": "2023-07-28T18:21:15",
+        "end_date": null,
+        "flow_removed_at": null,
+        "updated_at": "2023-07-28T23:02:04"
+    },
+    "cbee9338673946": {
+        "active": true,
+        "archived": false,
+        "backup_path": [],
+        "bandwidth": 0,
+        "circuit_scheduler": [],
+        "current_path": [
+            {
+                "id": "78282c4",
+                "endpoint_a": {
+                    "id": "00:00:00:00:00:00:00:01:3",
+                    "name": "s1-eth3",
+                    "port_number": 3,
+                    "mac": "16:bf:c9:82:e2:45",
+                    "switch": "00:00:00:00:00:00:00:01",
+                    "type": "interface",
+                    "nni": true,
+                    "uni": false,
+                    "speed": 1250000000.0,
+                    "metadata": {},
+                    "lldp": true,
+                    "active": true,
+                    "enabled": true,
+                    "status": "UP",
+                    "status_reason": [],
+                    "link": "78282c4"
+                },
+                "endpoint_b": {
+                    "id": "00:00:00:00:00:00:00:02:2",
+                    "name": "s2-eth2",
+                    "port_number": 2,
+                    "mac": "2e:cf:50:f4:78:27",
+                    "switch": "00:00:00:00:00:00:00:02",
+                    "type": "interface",
+                    "nni": true,
+                    "uni": false,
+                    "speed": 1250000000.0,
+                    "metadata": {},
+                    "lldp": true,
+                    "active": true,
+                    "enabled": true,
+                    "status": "UP",
+                    "status_reason": [],
+                    "link": "78282c4"
+                },
+                "metadata": {
+                    "s_vlan": {
+                        "tag_type": 1,
+                        "value": 2
+                    }
+                },
+                "active": true,
+                "enabled": true,
+                "status": "UP",
+                "status_reason": []
+            },
+            {
+                "id": "4d42dc0",
+                "endpoint_a": {
+                    "id": "00:00:00:00:00:00:00:02:3",
+                    "name": "s2-eth3",
+                    "port_number": 3,
+                    "mac": "7a:aa:59:ad:40:8d",
+                    "switch": "00:00:00:00:00:00:00:02",
+                    "type": "interface",
+                    "nni": true,
+                    "uni": false,
+                    "speed": 1250000000.0,
+                    "metadata": {},
+                    "lldp": true,
+                    "active": true,
+                    "enabled": true,
+                    "status": "UP",
+                    "status_reason": [],
+                    "link": "4d42dc0"
+                },
+                "endpoint_b": {
+                    "id": "00:00:00:00:00:00:00:03:2",
+                    "name": "s3-eth2",
+                    "port_number": 2,
+                    "mac": "72:4b:26:d0:d5:99",
+                    "switch": "00:00:00:00:00:00:00:03",
+                    "type": "interface",
+                    "nni": true,
+                    "uni": false,
+                    "speed": 1250000000.0,
+                    "metadata": {},
+                    "lldp": true,
+                    "active": true,
+                    "enabled": true,
+                    "status": "UP",
+                    "status_reason": [],
+                    "link": "4d42dc0"
+                },
+                "metadata": {
+                    "s_vlan": {
+                        "tag_type": 1,
+                        "value": 2
+                    }
+                },
+                "active": true,
+                "enabled": true,
+                "status": "UP",
+                "status_reason": []
+            }
+        ],
+        "dynamic_backup_path": false,
+        "enabled": true,
+        "failover_path": [],
+        "id": "cbee9338673946",
+        "metadata": {},
+        "name": "epl_static",
+        "primary_path": [
+            {
+                "id": "78282c4",
+                "endpoint_a": {
+                    "id": "00:00:00:00:00:00:00:01:3",
+                    "name": "s1-eth3",
+                    "port_number": 3,
+                    "mac": "16:bf:c9:82:e2:45",
+                    "switch": "00:00:00:00:00:00:00:01",
+                    "type": "interface",
+                    "nni": true,
+                    "uni": false,
+                    "speed": 1250000000.0,
+                    "metadata": {},
+                    "lldp": true,
+                    "active": true,
+                    "enabled": true,
+                    "status": "UP",
+                    "status_reason": [],
+                    "link": "78282c4"
+                },
+                "endpoint_b": {
+                    "id": "00:00:00:00:00:00:00:02:2",
+                    "name": "s2-eth2",
+                    "port_number": 2,
+                    "mac": "2e:cf:50:f4:78:27",
+                    "switch": "00:00:00:00:00:00:00:02",
+                    "type": "interface",
+                    "nni": true,
+                    "uni": false,
+                    "speed": 1250000000.0,
+                    "metadata": {},
+                    "lldp": true,
+                    "active": true,
+                    "enabled": true,
+                    "status": "UP",
+                    "status_reason": [],
+                    "link": "78282c4"
+                },
+                "metadata": {
+                    "s_vlan": {
+                        "tag_type": 1,
+                        "value": 2
+                    }
+                },
+                "active": true,
+                "enabled": true,
+                "status": "UP",
+                "status_reason": []
+            },
+            {
+                "id": "4d42dc0",
+                "endpoint_a": {
+                    "id": "00:00:00:00:00:00:00:02:3",
+                    "name": "s2-eth3",
+                    "port_number": 3,
+                    "mac": "7a:aa:59:ad:40:8d",
+                    "switch": "00:00:00:00:00:00:00:02",
+                    "type": "interface",
+                    "nni": true,
+                    "uni": false,
+                    "speed": 1250000000.0,
+                    "metadata": {},
+                    "lldp": true,
+                    "active": true,
+                    "enabled": true,
+                    "status": "UP",
+                    "status_reason": [],
+                    "link": "4d42dc0"
+                },
+                "endpoint_b": {
+                    "id": "00:00:00:00:00:00:00:03:2",
+                    "name": "s3-eth2",
+                    "port_number": 2,
+                    "mac": "72:4b:26:d0:d5:99",
+                    "switch": "00:00:00:00:00:00:00:03",
+                    "type": "interface",
+                    "nni": true,
+                    "uni": false,
+                    "speed": 1250000000.0,
+                    "metadata": {},
+                    "lldp": true,
+                    "active": true,
+                    "enabled": true,
+                    "status": "UP",
+                    "status_reason": [],
+                    "link": "4d42dc0"
+                },
+                "metadata": {
+                    "s_vlan": {
+                        "tag_type": 1,
+                        "value": 2
+                    }
+                },
+                "active": true,
+                "enabled": true,
+                "status": "UP",
+                "status_reason": []
+            }
+        ],
+        "service_level": 0,
+        "uni_a": {
+            "interface_id": "00:00:00:00:00:00:00:01:1"
+        },
+        "uni_z": {
+            "interface_id": "00:00:00:00:00:00:00:03:1"
+        },
+        "sb_priority": null,
+        "execution_rounds": 0,
+        "owner": null,
+        "queue_id": null,
+        "primary_constraints": {},
+        "secondary_constraints": {},
+        "primary_links": [],
+        "backup_links": [],
+        "start_date": "2023-07-28T23:30:59",
+        "creation_time": "2023-07-28T23:30:59",
+        "request_time": "2023-07-28T23:30:59",
+        "end_date": null,
+        "flow_removed_at": null,
+        "updated_at": "2023-07-28T23:30:59"
+    }
+}
+"""
+    return json.loads(data)
+
+
+@pytest.fixture
+def intra_evc_evpl_flows_data() -> dict:
+    """Intra EVC EVPL flows data."""
+    data = """
+{
+    "00:00:00:00:00:00:00:01": [
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12265385089372284745,
+                "match": {
+                    "in_port": 1,
+                    "dl_vlan": 200
+                },
+                "actions": [
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": 200
+                    },
+                    {
+                        "action_type": "output",
+                        "port": 2
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "898c09a40b5e3e892b815c2a6bad532d",
+            "id": "f7562d356cd900cb227b018ef27c5189",
+            "inserted_at": "2023-07-28T18:21:15.875000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:01",
+            "updated_at": "2023-07-28T23:01:12.663000"
+        },
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12265385089372284745,
+                "match": {
+                    "in_port": 2,
+                    "dl_vlan": 200
+                },
+                "actions": [
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": 200
+                    },
+                    {
+                        "action_type": "output",
+                        "port": 1
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "9ea45a8287939d63f1d3409e89131a04",
+            "id": "10cf10fbc4d3c7e4c4b931ff217c81e8",
+            "inserted_at": "2023-07-28T18:21:15.875000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:01",
+            "updated_at": "2023-07-28T23:01:12.664000"
+        }
+    ]
+}
+"""
+    return json.loads(data)
+
+
+@pytest.fixture
+def intra_evc_epl_flows_data() -> dict:
+    """Intra EVC EPL flows data."""
+    data = """
+{
+    "00:00:00:00:00:00:00:01": [
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12265385089372284745,
+                "match": {
+                    "in_port": 1
+                },
+                "actions": [
+                    {
+                        "action_type": "output",
+                        "port": 2
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "epl",
+                "priority": 10000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "898c09a40b5e3e892b815c2a6bad532d",
+            "id": "f7562d356cd900cb227b018ef27c5189",
+            "inserted_at": "2023-07-28T18:21:15.875000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:01",
+            "updated_at": "2023-07-28T23:01:12.663000"
+        },
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12265385089372284745,
+                "match": {
+                    "in_port": 2,
+                },
+                "actions": [
+                    {
+                        "action_type": "output",
+                        "port": 1
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "epl",
+                "priority": 10000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "9ea45a8287939d63f1d3409e89131a04",
+            "id": "10cf10fbc4d3c7e4c4b931ff217c81e8",
+            "inserted_at": "2023-07-28T18:21:15.875000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:01",
+            "updated_at": "2023-07-28T23:01:12.664000"
+        }
+    ]
+}
+"""
+    return json.loads(data)

--- a/tests/unit/test_kytos_api_helper.py
+++ b/tests/unit/test_kytos_api_helper.py
@@ -1,0 +1,51 @@
+"""Test kytos_api_helper.py"""
+from unittest.mock import MagicMock
+from napps.kytos.telemetry_int.kytos_api_helper import get_evcs, get_evc, get_evc_flows
+
+
+def test_get_evcs(evcs_data, monkeypatch) -> None:
+    """Test get_evcs."""
+    httpx_mock, resp_mock = MagicMock(), MagicMock()
+    resp_mock.json.return_value = evcs_data
+    httpx_mock.return_value = resp_mock
+    monkeypatch.setattr("httpx.get", httpx_mock)
+    data = get_evcs()
+    assert (
+        httpx_mock.call_args[0][0]
+        == "http://0.0.0.0:8181/api/kytos/mef_eline/v2/evc/?archived=false"
+    )
+    assert list(data.keys()) == ["3766c105686749", "cbee9338673946"]
+
+
+def test_get_evc(evcs_data, monkeypatch) -> None:
+    """Test get_evc."""
+    evc_id = "3766c105686749"
+    evc_data = evcs_data[evc_id]
+    httpx_mock, resp_mock = MagicMock(), MagicMock()
+    resp_mock.json.return_value = evc_data
+    httpx_mock.return_value = resp_mock
+    monkeypatch.setattr("httpx.get", httpx_mock)
+    data = get_evc(evc_id)
+    assert (
+        httpx_mock.call_args[0][0]
+        == f"http://0.0.0.0:8181/api/kytos/mef_eline/v2/evc/{evc_id}"
+    )
+    assert data[evc_id] == evc_data
+
+
+def test_get_evc_flows(monkeypatch, intra_evc_evpl_flows_data) -> None:
+    """Test get_evc_flows."""
+    evc_data = intra_evc_evpl_flows_data
+    dpid = "00:00:00:00:00:00:00:01"
+    cookie = evc_data[dpid][0]["flow"]["cookie"]
+    httpx_mock, resp_mock = MagicMock(), MagicMock()
+    resp_mock.json.return_value = evc_data
+    httpx_mock.return_value = resp_mock
+    monkeypatch.setattr("httpx.get", httpx_mock)
+    data = get_evc_flows(cookie, dpid)
+    assert (
+        httpx_mock.call_args[0][0]
+        == f"http://0.0.0.0:8181/api/kytos/flow_manager/v2/stored_flows?cookie_range={cookie}&cookie_range={cookie}&state=installed&state=pending&dpid={dpid}"
+    )
+    assert len(data) == 1
+    assert len(data[dpid]) == 2

--- a/tests/unit/test_kytos_api_helper.py
+++ b/tests/unit/test_kytos_api_helper.py
@@ -45,7 +45,9 @@ def test_get_evc_flows(monkeypatch, intra_evc_evpl_flows_data) -> None:
     data = get_evc_flows(cookie, dpid)
     assert (
         httpx_mock.call_args[0][0]
-        == f"http://0.0.0.0:8181/api/kytos/flow_manager/v2/stored_flows?cookie_range={cookie}&cookie_range={cookie}&state=installed&state=pending&dpid={dpid}"
+        == "http://0.0.0.0:8181/api/kytos/flow_manager/v2/stored_flows?"
+        f"cookie_range={cookie}&cookie_range={cookie}"
+        f"&state=installed&state=pending&dpid={dpid}"
     )
     assert len(data) == 1
     assert len(data[dpid]) == 2

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,151 @@
+"""Test utils."""
+import pytest
+from napps.kytos.telemetry_int.utils import (
+    get_evc_unis,
+    get_id_from_cookie,
+    get_new_cookie,
+    has_int_enabled,
+    is_intra_switch_evc,
+    set_instructions_from_actions,
+    set_new_cookie,
+)
+
+
+@pytest.mark.parametrize(
+    "flow,expected",
+    [
+        (
+            {
+                "flow": {
+                    "priority": 100,
+                    "match": {"in_port": 100},
+                    "actions": [{"action_type": "output", "port": 1}],
+                }
+            },
+            {
+                "flow": {
+                    "priority": 100,
+                    "match": {"in_port": 100},
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "output", "port": 1}],
+                        }
+                    ],
+                }
+            },
+        ),
+        (
+            {
+                "flow": {
+                    "priority": 100,
+                    "match": {"in_port": 100},
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "output", "port": 1}],
+                        }
+                    ],
+                }
+            },
+            {
+                "flow": {
+                    "priority": 100,
+                    "match": {"in_port": 100},
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "output", "port": 1}],
+                        }
+                    ],
+                }
+            },
+        ),
+    ],
+)
+def test_instructions_from_actions(flow, expected) -> None:
+    """Test instructions from actions."""
+    assert set_instructions_from_actions(flow) == expected
+
+
+@pytest.mark.parametrize(
+    "cookie,expected",
+    [
+        (0xAA3766C105686749, 0xA83766C105686749),
+        (0xAACBEE9338673946, 0xA8CBEE9338673946),
+    ],
+)
+def test_get_new_cookie(cookie, expected) -> None:
+    """test get_new_cookie."""
+    assert get_new_cookie(cookie) == expected
+
+
+@pytest.mark.parametrize(
+    "cookie,expected_evc_id",
+    [
+        (0xAA3766C105686749, "3766c105686749"),
+        (0xAACBEE9338673946, "cbee9338673946"),
+    ],
+)
+def test_get_id_from_cookie(cookie, expected_evc_id) -> None:
+    """test get_id_from_cookie."""
+    assert get_id_from_cookie(cookie) == expected_evc_id
+
+
+def test_set_new_cookie() -> None:
+    """Test set_new_cookie."""
+    flow = {"flow": {"cookie": 0xAA3766C105686749}}
+    set_new_cookie(flow)
+    assert flow["flow"]["cookie"] == 0xA83766C105686749
+
+
+@pytest.mark.parametrize(
+    "evc_dict,expected",
+    [
+        ({"metadata": {"telemetry": {"enabled": True}}}, True),
+        ({"metadata": {"telemetry": {"enabled": False}}}, False),
+        ({"metadata": {}}, False),
+    ],
+)
+def test_has_int_enabled(evc_dict, expected) -> None:
+    """test has_int_enabled."""
+    assert has_int_enabled(evc_dict) == expected
+
+
+def test_get_evc_unis() -> None:
+    """test get_evc_unis."""
+    evc = {
+        "uni_a": {
+            "tag": {"tag_type": 1, "value": 200},
+            "interface_id": "00:00:00:00:00:00:00:01:1",
+        },
+        "uni_z": {
+            "tag": {"tag_type": 1, "value": 200},
+            "interface_id": "00:00:00:00:00:00:00:01:2",
+        },
+    }
+    uni_a, uni_z = get_evc_unis(evc)
+    assert uni_a["interface_id"] == evc["uni_a"]["interface_id"]
+    assert uni_a["port_number"] == 1
+    assert uni_a["switch"] == "00:00:00:00:00:00:00:01"
+
+    assert uni_z["interface_id"] == evc["uni_z"]["interface_id"]
+    assert uni_z["port_number"] == 2
+    assert uni_z["switch"] == "00:00:00:00:00:00:00:01"
+
+
+def test_is_intra_switch_evc() -> None:
+    """test is_instra_switch_evc."""
+    evc = {
+        "uni_a": {
+            "tag": {"tag_type": 1, "value": 200},
+            "interface_id": "00:00:00:00:00:00:00:01:1",
+        },
+        "uni_z": {
+            "tag": {"tag_type": 1, "value": 200},
+            "interface_id": "00:00:00:00:00:00:00:01:2",
+        },
+    }
+    assert is_intra_switch_evc(evc)
+    evc["uni_a"]["interface_id"] = "00:00:00:00:00:00:00:02:1"
+    assert not is_intra_switch_evc(evc)


### PR DESCRIPTION
Closes #14

### Summary

- Replaced `v2/flows` with `v2/stored_flows`
- Added support to convert from `actions` to `instructions` to work as expected with `v2/stored_flows`
- Added more 14 unit tests
- General refactorings
- Left TODOs in the code that will address on subsequent PRs

(this NApp changelog will only be updated in subsequent PRs)

### Local Tests

I enabled and disabled INT using this topology, but only comparing the flows and not completely pushing it:


![20230801_120220](https://github.com/kytos-ng/telemetry_int/assets/1010796/9b8dcd22-9ca2-41f6-8914-16458cce00e8)

```
2023-08-02 16:44:42,856 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47938 - "POST /api/kytos/telemetry_int/v1/evc/enable/ HTTP/1.1" 200
2023-08-02 16:44:48,219 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:55270 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 400
2023-08-02 16:44:54,941 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47504 - "GET /api/kytos/mef_eline/v2/evc/c96aff17426546x HTTP/1.1" 404
2023-08-02 16:44:54,943 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47494 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 404
2023-08-02 16:44:58,347 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47516 - "GET /api/kytos/mef_eline/v2/evc/c96aff17426546 HTTP/1.1" 200
2023-08-02 16:44:58,365 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47518 - "POST /api/kytos/mef_eline/v2/evc/c96aff17426546/metadata HTTP/1.1" 201
2023-08-02 16:44:58,367 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47494 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 200
2023-08-02 16:44:59,570 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47524 - "GET /api/kytos/mef_eline/v2/evc/c96aff17426546 HTTP/1.1" 200
2023-08-02 16:44:59,572 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47494 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 400
2023-08-02 16:45:00,344 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47528 - "GET /api/kytos/mef_eline/v2/evc/c96aff17426546 HTTP/1.1" 200
2023-08-02 16:45:00,345 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47494 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 400
```


### End-to-End Tests

N/A yet