### PR TITLE
refactor: updated telemetry metadata payload based on augmented EP031

### DIFF
--- a/managers/int.py
+++ b/managers/int.py
@@ -52,7 +52,9 @@ class INTManager:
         metadata = {
             "telemetry": {
                 "enabled": False,
-                "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
+                "status": "DOWN",
+                "status_reason": ["disabled"],
+                "status_updated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
             }
         }
         await asyncio.gather(
@@ -89,7 +91,9 @@ class INTManager:
         metadata = {
             "telemetry": {
                 "enabled": True,
-                "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
+                "status": "UP",
+                "status_reason": [],
+                "status_updated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
             }
         }
         await asyncio.gather(

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -36,12 +36,17 @@ class TestINTManager:
         """Test enable INT metadata args."""
         controller = MagicMock()
         api_mock = AsyncMock()
+        stored_flows_mock = AsyncMock()
         monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
+        monkeypatch.setattr(
+            "napps.kytos.telemetry_int.utils.get_found_stored_flows", stored_flows_mock
+        )
 
         int_manager = INTManager(controller)
         int_manager.remove_int_flows = AsyncMock()
         await int_manager.enable_int({}, False)
 
+        assert stored_flows_mock.call_count == 1
         assert api_mock.add_evcs_metadata.call_count == 1
         args = api_mock.add_evcs_metadata.call_args[0]
         assert args[0] == {}

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -1,0 +1,55 @@
+"""Test INTManager"""
+
+from unittest.mock import AsyncMock, MagicMock
+from napps.kytos.telemetry_int.managers.int import INTManager
+
+
+class TestINTManager:
+
+    """TestINTManager."""
+
+    async def test_disable_int_metadata(self, monkeypatch) -> None:
+        """Test disable INT metadata args."""
+        controller = MagicMock()
+        api_mock = AsyncMock()
+        monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
+
+        int_manager = INTManager(controller)
+        int_manager.remove_int_flows = AsyncMock()
+        await int_manager.disable_int({}, False)
+
+        assert api_mock.add_evcs_metadata.call_count == 1
+        args = api_mock.add_evcs_metadata.call_args[0]
+        assert args[0] == {}
+        assert "telemetry" in args[1]
+        telemetry_dict = args[1]["telemetry"]
+        expected_keys = ["enabled", "status", "status_reason", "status_updated_at"]
+        assert sorted(list(telemetry_dict.keys())) == sorted(expected_keys)
+
+        assert not telemetry_dict["enabled"]
+        assert telemetry_dict["status"] == "DOWN"
+        assert telemetry_dict["status_reason"] == ["disabled"]
+
+        assert args[2] is False
+
+    async def test_enable_int_metadata(self, monkeypatch) -> None:
+        """Test enable INT metadata args."""
+        controller = MagicMock()
+        api_mock = AsyncMock()
+        monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
+
+        int_manager = INTManager(controller)
+        int_manager.remove_int_flows = AsyncMock()
+        await int_manager.enable_int({}, False)
+
+        assert api_mock.add_evcs_metadata.call_count == 1
+        args = api_mock.add_evcs_metadata.call_args[0]
+        assert args[0] == {}
+        assert "telemetry" in args[1]
+        telemetry_dict = args[1]["telemetry"]
+        expected_keys = ["enabled", "status", "status_reason", "status_updated_at"]
+        assert sorted(list(telemetry_dict.keys())) == sorted(expected_keys)
+
+        assert telemetry_dict["enabled"] is True
+        assert telemetry_dict["status"] == "UP"
+        assert telemetry_dict["status_reason"] == []


### PR DESCRIPTION
Closes #45 

This PR is on top of PR #35 

### Summary

- Updated telemetry metadata payload based on augmented EP031 
- (changelog not updated since this NApps hasn't been released yet)

### Local Tests

- Enabled and disabled an INT intra-EVC on a NoviFlow switch too:

```
2023-08-31 10:21:06,215 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57940 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-08-31 10:21:06,239 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57918 - "POST /api/kytos/telemetry_int/v1/evc/enable HTTP/1.1" 201
2023-08-31 10:21:10,822 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57918 - "GET /api/kytos/mef_eline/v2/evc/6c600b72e3c34b HTTP/1.1" 200
2023-08-31 10:21:37,185 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37934 - "GET /api/kytos/mef_eline/v2/evc/6c600b72e3c34b HTTP/1.1" 200
2023-08-31 10:21:37,189 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Disabling INT on EVC ids: ['6c600b72e3c34b'], force: False
2023-08-31 10:21:37,229 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37936 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending&cookie_range=1213618069814508013
9&cookie_range=12136180698145080139 HTTP/1.1" 200
2023-08-31 10:21:37,261 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_11) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12136180698145080139, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2023-08-31 10:21:37,278 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37940 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-08-31 10:21:37,281 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37930 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 200
2023-08-31 10:21:40,692 - INFO [uvicorn.access] (MainThread) 127.0.0.1:37930 - "GET /api/kytos/mef_eline/v2/evc/6c600b72e3c34b HTTP/1.1" 200
```


```
{
    "active": true,
    "archived": false,
    "backup_path": [],
    "bandwidth": 0,
    "circuit_scheduler": [],
    "current_path": [],
    "dynamic_backup_path": true,
    "enabled": true,
    "failover_path": [],
    "id": "6c600b72e3c34b",
    "metadata": {
        "telemetry": {
            "enabled": true,
            "status": "UP",
            "status_reason": [],
            "status_updated_at": "2023-08-31T13:21:06"
        }
    },
    "name": "evpl_intra_evc_int",
    "primary_path": [],
    "service_level": 7,
    "uni_a": {
        "tag": {
            "tag_type": 1,
            "value": 100
        },
        "interface_id": "00:00:00:00:00:00:00:01:15"
    },
    "uni_z": {
        "tag": {
            "tag_type": 1,
            "value": 100
        },
        "interface_id": "00:00:00:00:00:00:00:01:16"
    },
    "sb_priority": null,
    "execution_rounds": 0,
    "owner": null,
    "queue_id": -1,
    "primary_constraints": {},
    "secondary_constraints": {},
    "primary_links": [],
    "backup_links": [],
    "start_date": "2023-08-31T13:20:54",
    "creation_time": "2023-08-31T13:20:54",
    "request_time": "2023-08-31T13:20:54",
    "end_date": null,
    "flow_removed_at": null,
    "updated_at": "2023-08-31T13:20:55"
}
```

```
{
    "active": true,
    "archived": false,
    "backup_path": [],
    "bandwidth": 0,
    "circuit_scheduler": [],
    "current_path": [],
    "dynamic_backup_path": true,
    "enabled": true,
    "failover_path": [],
    "id": "6c600b72e3c34b",
    "metadata": {
        "telemetry": {
            "enabled": false,
            "status": "DOWN",
            "status_reason": [
                "disabled"
            ],
            "status_updated_at": "2023-08-31T13:21:37"
        }
    },
    "name": "evpl_intra_evc_int",
    "primary_path": [],
    "service_level": 7,
    "uni_a": {
        "tag": {
            "tag_type": 1,
            "value": 100
        },
        "interface_id": "00:00:00:00:00:00:00:01:15"
    },
    "uni_z": {
        "tag": {
            "tag_type": 1,
            "value": 100
        },
        "interface_id": "00:00:00:00:00:00:00:01:16"
    },
    "sb_priority": null,
    "execution_rounds": 0,
    "owner": null,
    "queue_id": -1,
    "primary_constraints": {},
    "secondary_constraints": {},
    "primary_links": [],
    "backup_links": [],
    "start_date": "2023-08-31T13:20:54",
    "creation_time": "2023-08-31T13:20:54",
    "request_time": "2023-08-31T13:20:54",
    "end_date": null,
    "flow_removed_at": null,
    "updated_at": "2023-08-31T13:20:55"
}
```

### End-to-End Tests

N/A
