### PR TITLE
fix: fixed intra-evc source flows destination proxy port

### DIFF
--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -108,6 +108,12 @@ def _build_int_source_flows(
                         # The choice for destination is at the INT Sink.
                         action["port"] = proxy_port.source.port_number
 
+                # remove set_vlan action if it exists, this is for
+                # avoding a redundant set_vlan since it'll be set in the egress sink
+                instruction["actions"] = utils.modify_actions(
+                    instruction["actions"], ["set_vlan"], remove=True
+                )
+
     instructions = utils.add_to_apply_actions(
         new_int_flow_tbl_2["flow"]["instructions"],
         new_instruction={"action_type": "add_int_metadata"},

--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -50,7 +50,6 @@ def _build_int_source_flows(
     new_flows = []
     new_int_flow_tbl_0_tcp = {}
     src_uni = evc[uni_src_key]
-    proxy_port = src_uni["proxy_port"]
 
     # Get the original flows
     dpid = src_uni["switch"]
@@ -95,8 +94,10 @@ def _build_int_source_flows(
     new_int_flow_tbl_2["flow"]["table_id"] = settings.INT_TABLE
     utils.set_table_group(new_int_flow_tbl_2)
 
-    # if intra-switch EVC, then output port should be the proxy
+    # if intra-switch EVC, then output port should be the dst UNI's source port
     if utils.is_intra_switch_evc(evc):
+        dst_uni = evc["uni_z" if uni_src_key == "uni_a" else "uni_a"]
+        proxy_port = dst_uni["proxy_port"]
         for instruction in new_int_flow_tbl_2["flow"]["instructions"]:
             if instruction["instruction_type"] == "apply_actions":
                 for action in instruction["actions"]:


### PR DESCRIPTION
Closes #49 
Closes #48 

### Summary

- Fixed intra-evc source flows destination proxy port, data plane is now working
- Avoided extra redundant 'set_vlan' for intra-evc'
(This NApp hasn't been released yet no need to update changelog)

### Local Tests

- Tested the data plane on NoviFlow lab using `Novi01` and `Novi06`. 

```
                        +--------+
                        |        |
                        |        |
                        |        |
                        |        |
                     17 |      18|
               +--------+--------v--+
               |                    | 19
         15    |                    +-----------+
 --------------+                    |           |
               |                    |           |
               |      sw1           |           |
        16     |                    |20         |
---------------+                    <-----------+
               |                    |
               |                    |
               +--------------------+
```

- Novi01 intra-EVC symmetric vlan 100 between ports 15 and 16, and loops on 17-18, 19-20 respectively 
- Novi01 intra-EVC assymetric vlan 201-200 between ports 15 and 16, and loops on 17-18, 19-20 respectively 

(I've also collected the stored flows that will be used for unit tests, including on sdntrace_cp)

### End-to-End Tests

N/A
