### PR TITLE
chore: handled `OFPT_ERROR`

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,10 +4,11 @@ Napp to deploy In-band Network Telemetry over Ethernet Virtual Circuits
 
 """
 
+from datetime import datetime
+
 import napps.kytos.telemetry_int.kytos_api_helper as api
 from napps.kytos.telemetry_int import settings, utils
 from tenacity import RetryError
-from datetime import datetime
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import alisten_to
@@ -202,8 +203,8 @@ class Main(KytosNApp):
             await self.int_manager.remove_int_flows(stored_flows)
 
     @alisten_to("kytos/flow_manager.flow.error")
-    async def handle_flow_mod_error(self, event: KytosEvent):
-        """Handle flow mod errors.
+    async def on_flow_mod_error(self, event: KytosEvent):
+        """On flow mod errors.
 
         Only OFPT_ERRORs will be handled, telemetry_int already uses force: true
         """
@@ -221,7 +222,7 @@ class Main(KytosNApp):
         }
         evc_id = utils.get_id_from_cookie(flow.cookie)
         evcs = {evc_id: {evc_id: evc_id}}
-        await api.add_evcs_metadata(evcs, metadata, force=True),
+        await api.add_evcs_metadata(evcs, metadata, force=True)
 
     # Event-driven methods: future
     def listen_for_new_evcs(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,13 +1,29 @@
 """Test Main methods."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+from napps.kytos.telemetry_int.main import Main
+from kytos.lib.helpers import get_controller_mock
+from kytos.core.events import KytosEvent
+
 
 class TestMain:
     """Tests for the Main class."""
 
     def setup_method(self):
         """Setup."""
-        pass
+        patch("kytos.core.helpers.run_on_thread", lambda x: x).start()
+        # pylint: disable=import-outside-toplevel
+        controller = get_controller_mock()
+        self.napp = Main(controller)
 
-    def test_empty(self) -> None:
-        """Test empty."""
-        pass
+    async def test_on_flow_mod_error(self, monkeypatch) -> None:
+        """Test on_flow_mod_error."""
+        api_mock, flow = AsyncMock(), MagicMock()
+        flow.cookie = 1
+        monkeypatch.setattr(
+            "napps.kytos.telemetry_int.main.api",
+            api_mock,
+        )
+        event = KytosEvent(content={"flow": flow})
+        await self.napp.on_flow_mod_error(event)
+        assert api_mock.add_evcs_metadata.call_count == 1


### PR DESCRIPTION
Closes #44 

This PR is on top of PR #50 

### Summary

- Gracefully handled `OFPT_ERROR`, updating the EVC metadata accordingly. In the future, once this NApp is also tracking EVC states for convergence subsequent redundant requests wouldn't be needed, this will be addressed in the future. For now, it's OK especially since OFPT_ERROR won't keep looping unless the client calling the API is misbehaving (which for now we also do have full control and it's not completely exposed).
- No need to update changelog yet this NApp hasn't been released.

### Local Tests

- Simulated an `OFPT_ERROR` worked as expected:

```
{
    "active": true,
    "archived": false,
    "backup_path": [],
    "bandwidth": 0,
    "circuit_scheduler": [],
    "current_path": [],
    "dynamic_backup_path": true,
    "enabled": true,
    "failover_path": [],
    "id": "9098947c1cbd45",
    "metadata": {
        "telemetry": {
            "enabled": false,
            "status": "DOWN",
            "status_reason": [
                "ofpt_error"
            ],
            "status_updated_at": "2023-09-14T20:20:10"
        }
    },
    "name": "evpl",
    "primary_path": [],
    "service_level": 6,
    "uni_a": {
        "tag": {
            "tag_type": 1,
            "value": 200
        },
        "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
        "tag": {
            "tag_type": 1,
            "value": 200
        },
        "interface_id": "00:00:00:00:00:00:00:01:2"
    },
    "sb_priority": null,
    "execution_rounds": 0,
    "owner": null,
    "queue_id": -1,
    "primary_constraints": {},
    "secondary_constraints": {},
    "primary_links": [],
    "backup_links": [],
    "start_date": "2023-09-14T20:19:57",
    "creation_time": "2023-09-14T20:19:57",
    "request_time": "2023-09-14T20:19:57",
    "end_date": null,
    "flow_removed_at": null,
    "updated_at": "2023-09-14T20:19:57"
}
```

```
2023-09-14 17:20:09,990 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51420 - "GET /api/kytos/mef_eline/v2/evc/9098947c1cbd45 HTTP/1.1" 200
2023-09-14 17:20:09,991 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Enabling INT on EVC ids: ['9098947c1cbd45'], force: False
2023-09-14 17:20:10,001 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51430 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2023-09-14 17:20:10,011 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_3) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: True,  flows[0, 10]:
 [{'owner': 'telemetry_int', 'cookie': 12146375958523067717, 'match': {'in_port': 1, 'dl_vlan': 200, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 2
0100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_i
d': 2}]}, {'owner': 'telemetry_int', 'cookie': 12146375958523067717, 'match': {'in_port': 1, 'dl_vlan': 200, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'pri
ority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table',
 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12146375958523067717, 'match': {'in_port': 1, 'dl_vlan': 200}, 'table_id': 2, 'table_group': 'base', 'priority': 20000, 'idle_tim
eout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 7}]}]}, {'owner': 
'telemetry_int', 'cookie': 12146375958523067717, 'match': {'in_port': 2, 'dl_vlan': 200, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_
timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'
owner': 'telemetry_int', 'cookie': 12146375958523067717, 'match': {'in_port': 2, 'dl_vlan': 200, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 2010
0, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id':
 2}]}, {'owner': 'telemetry_int', 'cookie': 12146375958523067717, 'match': {'in_port': 2, 'dl_vlan': 200}, 'table_id': 2, 'table_group': 'base', 'priority': 20000, 'idle_timeout': 0, 'h
ard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 5}]}]}, {'owner': 'telemetry_i
nt', 'cookie': 12146375958523067717, 'match': {'in_port': 8, 'dl_vlan': 200}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instruction
s': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 121463
75958523067717, 'match': {'in_port': 8, 'dl_vlan': 200}, 'table_id': 2, 'table_group': 'base', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_ty
pe': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'set_vlan', 'vlan_id': 200}, {'action_type': 'output', 'port': 2}]}]}, {'owner': 'telemetry_int', 'cookie':
 12146375958523067717, 'match': {'in_port': 6, 'dl_vlan': 200}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruc
tion_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12146375958523067717
, 'match': {'in_port': 6, 'dl_vlan': 200}, 'table_id': 2, 'table_group': 'base', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_ac
tions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'set_vlan', 'vlan_id': 200}, {'action_type': 'output', 'port': 1}]}]}]
2023-09-14 17:20:10,040 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51446 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,041 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 1703789362/0
x658dc332
2023-09-14 17:20:10,048 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51408 - "POST /api/kytos/telemetry_int/v1/evc/enable/ HTTP/1.1" 201
2023-09-14 17:20:10,041 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 949014006/0x
3890cdf6
2023-09-14 17:20:10,041 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 413552288/0x
18a64ea0
2023-09-14 17:20:10,041 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 436970352/0x
1a0ba370
2023-09-14 17:20:10,041 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 4232576368/0
xfc47fd70
2023-09-14 17:20:10,042 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 2516337748/0
x95fc4454
2023-09-14 17:20:10,042 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 3774058457/0
xe0f38fd9
2023-09-14 17:20:10,042 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 3745071735/0
xdf394277
2023-09-14 17:20:10,042 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 2130594785/0
x7efe4be1
2023-09-14 17:20:10,042 - ERROR [kytos.napps.kytos/of_core] (MainThread) OFPT_ERROR: type ErrorType.OFPET_BAD_ACTION, error code 2, from switch 00:00:00:00:00:00:00:01, xid 299032744/0x
11d2e0a8
2023-09-14 17:20:10,045 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_1) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1, 'dl_vla
n': 200, 'dl_type': 2048, 'nw_proto': 6}, 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': '36f27bd26630abb186db1cffdbe81b48', 'stats': {},
 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, xid: 1703789362
, cookie: 12146375958523067717, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,046 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_5) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 1, 'dl_vla
n': 200, 'dl_type': 2048, 'nw_proto': 17}, 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': '7f97f8b9a65258903d4530dcd0ba3360', 'stats': {}
, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, xid: 949014006
, cookie: 12146375958523067717, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,046 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_10) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 2, 'match': {'in_port': 1, 'dl_vl
an': 200}, 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': '8d547200aa13b45d4a5e0b800e7e89b2', 'stats': {}, 'cookie_mask': 0, 'instruction
s': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'port': 7, 'action_type': 'output'}]}]}, xid: 413552288, cookie: 12146375958523067717, error
: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,047 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_4) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 2, 'dl_vla
n': 200, 'dl_type': 2048, 'nw_proto': 6}, 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': 'f05ab4cff4a86e3cb9223c6f3b855361', 'stats': {},
 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, xid: 436970352,
 cookie: 12146375958523067717, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,049 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_0) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 2, 'dl_vla
n': 200, 'dl_type': 2048, 'nw_proto': 17}, 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': 'aae178e0a1891af5d4c550cf9c662279', 'stats': {}
, 'cookie_mask': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, xid: 423257636
8, cookie: 12146375958523067717, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,049 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_1) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 2, 'match': {'in_port': 2, 'dl_vla
n': 200}, 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': '947d9e8ab8b3cdba64f8e42f262f3067', 'stats': {}, 'cookie_mask': 0, 'instructions
': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'port': 5, 'action_type': 'output'}]}]}, xid: 2516337748, cookie: 12146375958523067717, error
: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,050 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_5) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 8, 'dl_vla
n': 200}, 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': '9126bd1d732caf7fd5ec5d834c7eed35', 'stats': {}, 'cookie_mask': 0, 'instructions
': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, xid: 3774058457, cookie: 1214637595852306771
7, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,050 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_3) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 2, 'match': {'in_port': 8, 'dl_vla
n': 200}, 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': '24393abf3e4a6edd19e4a4675703b492', 'stats': {}, 'cookie_mask': 0, 'instructions
': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'vlan_id': 200, 'action_type': 'set_vlan'}, {'port': 2, 'action_type': 'output'}]}]}, xid: 3745071735,
 cookie: 12146375958523067717, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,051 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_2) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 0, 'match': {'in_port': 6, 'dl_vla
n': 200}, 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': 'dad7ef76a0156878ca9f3e60f29fa0b1', 'stats': {}, 'cookie_mask': 0, 'instructions
': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, xid: 2130594785, cookie: 1214637595852306771
7, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,052 - WARNING [kytos.napps.kytos/flow_manager] (thread_pool_sb_10) Deleting flow: {'switch': '00:00:00:00:00:00:00:01', 'table_id': 2, 'match': {'in_port': 6, 'dl_vl
an': 200}, 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'cookie': 12146375958523067717, 'id': 'a732ffdee65f6a8b7ffe2629aeb48a5f', 'stats': {}, 'cookie_mask': 0, 'instruction
s': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'vlan_id': 200, 'action_type': 'set_vlan'}, {'port': 1, 'action_type': 'output'}]}]}, xid: 299032744,
 cookie: 12146375958523067717, error: {'error_command': 'add', 'error_type': UBInt16(<ErrorType.OFPET_BAD_ACTION: 2>), 'error_code': <BadActionCode.OFPBAC_BAD_EXPERIMENTER: 2>}
2023-09-14 17:20:10,057 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,065 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,072 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,080 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,088 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,095 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,102 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,109 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,116 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,122 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Disabling EVC(9098947c1cbd45) due to OFPT_ERROR
2023-09-14 17:20:10,155 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51496 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,156 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51526 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,156 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51510 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,156 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51500 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,157 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51460 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,157 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51484 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,158 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51514 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,158 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51536 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,159 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51504 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-09-14 17:20:10,161 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51476 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201

```

### End-to-End Tests

N/A yet
