### PR TITLE
fix: hop flows are not setting telemetry_int cookie correctly, added unit test for inter evpl

### DIFF
--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -151,7 +151,7 @@ def _build_int_hop_flows(
 
         new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
         utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
-        utils.set_new_cookie(flow)
+        utils.set_new_cookie(new_int_flow_tbl_0_tcp)
         utils.set_owner(new_int_flow_tbl_0_tcp)
 
         # Prepare TCP Flow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def evcs_data() -> dict:
         "flow_removed_at": null,
         "updated_at": "2023-07-28T23:02:04"
     },
-    "cbee9338673946": {
+    "16a76ae61b2f46": {
         "active": true,
         "archived": false,
         "backup_path": [],
@@ -60,12 +60,12 @@ def evcs_data() -> dict:
         "circuit_scheduler": [],
         "current_path": [
             {
-                "id": "78282c4",
+                "id": "78282c4d5",
                 "endpoint_a": {
                     "id": "00:00:00:00:00:00:00:01:3",
                     "name": "s1-eth3",
                     "port_number": 3,
-                    "mac": "16:bf:c9:82:e2:45",
+                    "mac": "7e:b7:b4:cd:dd:ad",
                     "switch": "00:00:00:00:00:00:00:01",
                     "type": "interface",
                     "nni": true,
@@ -77,13 +77,13 @@ def evcs_data() -> dict:
                     "enabled": true,
                     "status": "UP",
                     "status_reason": [],
-                    "link": "78282c4"
+                    "link": "78282c4d5"
                 },
                 "endpoint_b": {
                     "id": "00:00:00:00:00:00:00:02:2",
                     "name": "s2-eth2",
                     "port_number": 2,
-                    "mac": "2e:cf:50:f4:78:27",
+                    "mac": "a6:57:de:b1:a2:f6",
                     "switch": "00:00:00:00:00:00:00:02",
                     "type": "interface",
                     "nni": true,
@@ -95,12 +95,12 @@ def evcs_data() -> dict:
                     "enabled": true,
                     "status": "UP",
                     "status_reason": [],
-                    "link": "78282c4"
+                    "link": "78282c4d5"
                 },
                 "metadata": {
                     "s_vlan": {
                         "tag_type": 1,
-                        "value": 2
+                        "value": 1
                     }
                 },
                 "active": true,
@@ -109,12 +109,12 @@ def evcs_data() -> dict:
                 "status_reason": []
             },
             {
-                "id": "4d42dc0",
+                "id": "4d42dc085",
                 "endpoint_a": {
                     "id": "00:00:00:00:00:00:00:02:3",
                     "name": "s2-eth3",
                     "port_number": 3,
-                    "mac": "7a:aa:59:ad:40:8d",
+                    "mac": "4e:2e:61:6c:f4:c0",
                     "switch": "00:00:00:00:00:00:00:02",
                     "type": "interface",
                     "nni": true,
@@ -126,13 +126,13 @@ def evcs_data() -> dict:
                     "enabled": true,
                     "status": "UP",
                     "status_reason": [],
-                    "link": "4d42dc0"
+                    "link": "4d42dc085"
                 },
                 "endpoint_b": {
                     "id": "00:00:00:00:00:00:00:03:2",
                     "name": "s3-eth2",
                     "port_number": 2,
-                    "mac": "72:4b:26:d0:d5:99",
+                    "mac": "9e:84:49:fc:13:14",
                     "switch": "00:00:00:00:00:00:00:03",
                     "type": "interface",
                     "nni": true,
@@ -144,12 +144,12 @@ def evcs_data() -> dict:
                     "enabled": true,
                     "status": "UP",
                     "status_reason": [],
-                    "link": "4d42dc0"
+                    "link": "4d42dc085"
                 },
                 "metadata": {
                     "s_vlan": {
                         "tag_type": 1,
-                        "value": 2
+                        "value": 1
                     }
                 },
                 "active": true,
@@ -158,133 +158,50 @@ def evcs_data() -> dict:
                 "status_reason": []
             }
         ],
-        "dynamic_backup_path": false,
+        "dynamic_backup_path": true,
         "enabled": true,
         "failover_path": [],
-        "id": "cbee9338673946",
+        "id": "16a76ae61b2f46",
         "metadata": {},
-        "name": "epl_static",
-        "primary_path": [
-            {
-                "id": "78282c4",
-                "endpoint_a": {
-                    "id": "00:00:00:00:00:00:00:01:3",
-                    "name": "s1-eth3",
-                    "port_number": 3,
-                    "mac": "16:bf:c9:82:e2:45",
-                    "switch": "00:00:00:00:00:00:00:01",
-                    "type": "interface",
-                    "nni": true,
-                    "uni": false,
-                    "speed": 1250000000.0,
-                    "metadata": {},
-                    "lldp": true,
-                    "active": true,
-                    "enabled": true,
-                    "status": "UP",
-                    "status_reason": [],
-                    "link": "78282c4"
-                },
-                "endpoint_b": {
-                    "id": "00:00:00:00:00:00:00:02:2",
-                    "name": "s2-eth2",
-                    "port_number": 2,
-                    "mac": "2e:cf:50:f4:78:27",
-                    "switch": "00:00:00:00:00:00:00:02",
-                    "type": "interface",
-                    "nni": true,
-                    "uni": false,
-                    "speed": 1250000000.0,
-                    "metadata": {},
-                    "lldp": true,
-                    "active": true,
-                    "enabled": true,
-                    "status": "UP",
-                    "status_reason": [],
-                    "link": "78282c4"
-                },
-                "metadata": {
-                    "s_vlan": {
-                        "tag_type": 1,
-                        "value": 2
-                    }
-                },
-                "active": true,
-                "enabled": true,
-                "status": "UP",
-                "status_reason": []
-            },
-            {
-                "id": "4d42dc0",
-                "endpoint_a": {
-                    "id": "00:00:00:00:00:00:00:02:3",
-                    "name": "s2-eth3",
-                    "port_number": 3,
-                    "mac": "7a:aa:59:ad:40:8d",
-                    "switch": "00:00:00:00:00:00:00:02",
-                    "type": "interface",
-                    "nni": true,
-                    "uni": false,
-                    "speed": 1250000000.0,
-                    "metadata": {},
-                    "lldp": true,
-                    "active": true,
-                    "enabled": true,
-                    "status": "UP",
-                    "status_reason": [],
-                    "link": "4d42dc0"
-                },
-                "endpoint_b": {
-                    "id": "00:00:00:00:00:00:00:03:2",
-                    "name": "s3-eth2",
-                    "port_number": 2,
-                    "mac": "72:4b:26:d0:d5:99",
-                    "switch": "00:00:00:00:00:00:00:03",
-                    "type": "interface",
-                    "nni": true,
-                    "uni": false,
-                    "speed": 1250000000.0,
-                    "metadata": {},
-                    "lldp": true,
-                    "active": true,
-                    "enabled": true,
-                    "status": "UP",
-                    "status_reason": [],
-                    "link": "4d42dc0"
-                },
-                "metadata": {
-                    "s_vlan": {
-                        "tag_type": 1,
-                        "value": 2
-                    }
-                },
-                "active": true,
-                "enabled": true,
-                "status": "UP",
-                "status_reason": []
-            }
-        ],
-        "service_level": 0,
+        "name": "evpl",
+        "primary_path": [],
+        "service_level": 6,
         "uni_a": {
+            "tag": {
+                "tag_type": 1,
+                "value": 101
+            },
             "interface_id": "00:00:00:00:00:00:00:01:1"
         },
         "uni_z": {
+            "tag": {
+                "tag_type": 1,
+                "value": 102
+            },
             "interface_id": "00:00:00:00:00:00:00:03:1"
         },
         "sb_priority": null,
         "execution_rounds": 0,
         "owner": null,
-        "queue_id": null,
-        "primary_constraints": {},
-        "secondary_constraints": {},
+        "queue_id": -1,
+        "primary_constraints": {
+            "mandatory_metrics": {
+                "ownership": "blue"
+            }
+        },
+        "secondary_constraints": {
+            "mandatory_metrics": {
+                "ownership": "blue"
+            }
+        },
         "primary_links": [],
         "backup_links": [],
-        "start_date": "2023-07-28T23:30:59",
-        "creation_time": "2023-07-28T23:30:59",
-        "request_time": "2023-07-28T23:30:59",
+        "start_date": "2023-09-15T13:11:53",
+        "creation_time": "2023-09-15T13:11:53",
+        "request_time": "2023-09-15T13:11:53",
         "end_date": null,
         "flow_removed_at": null,
-        "updated_at": "2023-07-28T23:30:59"
+        "updated_at": "2023-09-15T13:11:53"
     }
 }
 """
@@ -422,6 +339,222 @@ def intra_evc_epl_flows_data() -> dict:
             "state": "installed",
             "switch": "00:00:00:00:00:00:00:01",
             "updated_at": "2023-07-28T23:01:12.664000"
+        }
+    ]
+}
+"""
+    return json.loads(data)
+
+
+@pytest.fixture
+def inter_evc_evpl_flows_data() -> None:
+    """inter evc evpl flows data."""
+    data = """
+{
+    "00:00:00:00:00:00:00:02": [
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12256167513504296774,
+                "match": {
+                    "in_port": 2,
+                    "dl_vlan": 1
+                },
+                "actions": [
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": 1
+                    },
+                    {
+                        "action_type": "output",
+                        "port": 3
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "4718c55780c7ff62be3fcb09f4e3d06f",
+            "id": "c96c36720cd2c9d761345588bf68c33a",
+            "inserted_at": "2023-09-15T13:11:53.147000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:02",
+            "updated_at": "2023-09-15T13:11:53.158000"
+        },
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12256167513504296774,
+                "match": {
+                    "in_port": 3,
+                    "dl_vlan": 1
+                },
+                "actions": [
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": 1
+                    },
+                    {
+                        "action_type": "output",
+                        "port": 2
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "f4f4950beaf5bc8cb4b86c6799e2759e",
+            "id": "aefa4b6945337beb3125b96c60ecce28",
+            "inserted_at": "2023-09-15T13:11:53.147000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:02",
+            "updated_at": "2023-09-15T13:11:53.158000"
+        }
+    ],
+    "00:00:00:00:00:00:00:01": [
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12256167513504296774,
+                "match": {
+                    "in_port": 1,
+                    "dl_vlan": 101
+                },
+                "actions": [
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": 102
+                    },
+                    {
+                        "action_type": "push_vlan",
+                        "tag_type": "s"
+                    },
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": 1
+                    },
+                    {
+                        "action_type": "output",
+                        "port": 3
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "97e07c78a6f19bb4b4c7a13d2fc2a1bc",
+            "id": "114d32fe5e21cbad93fe9881f579e9de",
+            "inserted_at": "2023-09-15T13:11:53.162000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:01",
+            "updated_at": "2023-09-15T13:11:53.184000"
+        },
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12256167513504296774,
+                "match": {
+                    "in_port": 3,
+                    "dl_vlan": 1
+                },
+                "actions": [
+                    {
+                        "action_type": "pop_vlan"
+                    },
+                    {
+                        "action_type": "output",
+                        "port": 1
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "40cdc7cbea439f4f714d2f2bc1dd0380",
+            "id": "9f15a56df3e30ef08745fdf16c5f389b",
+            "inserted_at": "2023-09-15T13:11:53.162000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:01",
+            "updated_at": "2023-09-15T13:11:53.184000"
+        }
+    ],
+    "00:00:00:00:00:00:00:03": [
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12256167513504296774,
+                "match": {
+                    "in_port": 1,
+                    "dl_vlan": 102
+                },
+                "actions": [
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": 101
+                    },
+                    {
+                        "action_type": "push_vlan",
+                        "tag_type": "s"
+                    },
+                    {
+                        "action_type": "set_vlan",
+                        "vlan_id": 1
+                    },
+                    {
+                        "action_type": "output",
+                        "port": 2
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "c3358aa562a5293443248ba6d551c623",
+            "id": "d830b9abbc4db82cd25169c0a91544b5",
+            "inserted_at": "2023-09-15T13:11:53.188000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:03",
+            "updated_at": "2023-09-15T13:11:53.201000"
+        },
+        {
+            "flow": {
+                "owner": "mef_eline",
+                "cookie": 12256167513504296774,
+                "match": {
+                    "in_port": 2,
+                    "dl_vlan": 1
+                },
+                "actions": [
+                    {
+                        "action_type": "pop_vlan"
+                    },
+                    {
+                        "action_type": "output",
+                        "port": 1
+                    }
+                ],
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0
+            },
+            "flow_id": "9b96726b751a36c83eaaaee243181160",
+            "id": "106216e182ee653cf1901c3170efee23",
+            "inserted_at": "2023-09-15T13:11:53.188000",
+            "state": "installed",
+            "switch": "00:00:00:00:00:00:00:03",
+            "updated_at": "2023-09-15T13:11:53.201000"
         }
     ]
 }

--- a/tests/unit/test_flow_builder_inter_evc.py
+++ b/tests/unit/test_flow_builder_inter_evc.py
@@ -1,0 +1,518 @@
+"""Test flow_builder."""
+
+from unittest.mock import MagicMock
+from napps.kytos.telemetry_int.managers import flow_builder as fb
+from napps.kytos.telemetry_int.managers.int import INTManager
+from napps.kytos.telemetry_int.utils import ProxyPort, get_cookie
+from napps.kytos.telemetry_int import settings
+from napps.kytos.telemetry_int.kytos_api_helper import _map_stored_flows_by_cookies
+from kytos.lib.helpers import get_controller_mock, get_switch_mock, get_interface_mock
+from kytos.core.common import EntityStatus
+
+
+def test_build_int_flows_inter_evpl(
+    evcs_data, inter_evc_evpl_flows_data, monkeypatch
+) -> None:
+    """Test build INT flows inter EVPL.
+
+               +----+                                              +----+
+              5|    |6                                            5|    |6
+           +---+----v---+            +------------+           +----+----v---+
+        1  |            |            |            |           |             |1
+    -------+            |3         2 |            |3        2 |             +-------
+     vlan  |     s1     +------------+    s2      +-----------+    s3       | vlan
+     101   |            |            |            |           |             | 102
+           |            |            |            |           |             |
+           +------------+            +------------+           +-------------+
+
+    """
+    controller = get_controller_mock()
+    int_manager = INTManager(controller)
+    get_proxy_port_or_raise = MagicMock()
+    monkeypatch.setattr(
+        "napps.kytos.telemetry_int.utils.get_proxy_port_or_raise",
+        get_proxy_port_or_raise,
+    )
+
+    evc_id = "16a76ae61b2f46"
+    dpid_a = "00:00:00:00:00:00:00:01"
+    mock_switch_a = get_switch_mock(dpid_a, 0x04)
+    mock_interface_a1 = get_interface_mock("s1-eth1", 1, mock_switch_a)
+    mock_interface_a1.id = f"{dpid_a}:{mock_interface_a1.port_number}"
+    mock_interface_a5 = get_interface_mock("s1-eth5", 5, mock_switch_a)
+    mock_interface_a1.metadata = {"proxy_port": mock_interface_a5.port_number}
+    mock_interface_a5.status = EntityStatus.UP
+    mock_interface_a6 = get_interface_mock("s1-eth6", 6, mock_switch_a)
+    mock_interface_a6.status = EntityStatus.UP
+    mock_interface_a5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_a5.port_number,
+                mock_interface_a6.port_number,
+            ]
+        }
+    }
+
+    dpid_z = "00:00:00:00:00:00:00:03"
+    mock_switch_z = get_switch_mock(dpid_z, 0x04)
+    mock_interface_z1 = get_interface_mock("s1-eth1", 1, mock_switch_z)
+    mock_interface_z1.status = EntityStatus.UP
+    mock_interface_z1.id = f"{dpid_z}:{mock_interface_z1.port_number}"
+    mock_interface_z5 = get_interface_mock("s1-eth5", 5, mock_switch_z)
+    mock_interface_z1.metadata = {"proxy_port": mock_interface_z5.port_number}
+    mock_interface_z5.status = EntityStatus.UP
+    mock_interface_z6 = get_interface_mock("s1-eth6", 6, mock_switch_z)
+    mock_interface_z6.status = EntityStatus.UP
+    mock_interface_z5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_z5.port_number,
+                mock_interface_z6.port_number,
+            ]
+        }
+    }
+
+    mock_switch_a.get_interface_by_port_no = lambda port_no: {
+        mock_interface_a5.port_number: mock_interface_a5,
+        mock_interface_a6.port_number: mock_interface_a6,
+    }[port_no]
+
+    mock_switch_z.get_interface_by_port_no = lambda port_no: {
+        mock_interface_z5.port_number: mock_interface_z5,
+        mock_interface_z6.port_number: mock_interface_z6,
+    }[port_no]
+
+    pp_a = ProxyPort(controller, source=mock_interface_a5)
+    assert pp_a.source == mock_interface_a5
+    assert pp_a.destination == mock_interface_a6
+    pp_z = ProxyPort(controller, source=mock_interface_z5)
+    assert pp_z.source == mock_interface_z5
+    assert pp_z.destination == mock_interface_z6
+
+    get_proxy_port_or_raise.side_effect = [pp_a, pp_z]
+    evcs_data = {evc_id: evcs_data[evc_id]}
+    evcs_data = int_manager._validate_map_enable_evcs(evcs_data)
+    stored_flows = _map_stored_flows_by_cookies(inter_evc_evpl_flows_data)
+
+    cookie = get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
+    flows = fb.build_int_flows(evcs_data, stored_flows)[cookie]
+
+    n_expected_source_flows, n_expected_hop_flows, n_expected_sink_flows = 3, 2, 4
+    assert (
+        len(flows)
+        == (n_expected_source_flows + n_expected_hop_flows + n_expected_sink_flows) * 2
+    )
+
+    expected_uni_a_source_flows = [
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 1, "dl_vlan": 101, "dl_type": 2048, "nw_proto": 6},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [{"action_type": "push_int"}],
+                    },
+                    {"instruction_type": "goto_table", "table_id": 2},
+                ],
+            }
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {
+                    "in_port": 1,
+                    "dl_vlan": 101,
+                    "dl_type": 2048,
+                    "nw_proto": 17,
+                },
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [{"action_type": "push_int"}],
+                    },
+                    {"instruction_type": "goto_table", "table_id": 2},
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 1, "dl_vlan": 101},
+                "table_id": 2,
+                "table_group": "base",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "set_vlan", "vlan_id": 102},
+                            {"action_type": "push_vlan", "tag_type": "s"},
+                            {"action_type": "set_vlan", "vlan_id": 1},
+                            {"action_type": "output", "port": 3},
+                        ],
+                    }
+                ],
+            },
+        },
+    ]
+
+    expected_uni_z_source_flows = [
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 1, "dl_vlan": 102, "dl_type": 2048, "nw_proto": 6},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [{"action_type": "push_int"}],
+                    },
+                    {"instruction_type": "goto_table", "table_id": 2},
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {
+                    "in_port": 1,
+                    "dl_vlan": 102,
+                    "dl_type": 2048,
+                    "nw_proto": 17,
+                },
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [{"action_type": "push_int"}],
+                    },
+                    {"instruction_type": "goto_table", "table_id": 2},
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 1, "dl_vlan": 102},
+                "table_id": 2,
+                "table_group": "base",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "set_vlan", "vlan_id": 101},
+                            {"action_type": "push_vlan", "tag_type": "s"},
+                            {"action_type": "set_vlan", "vlan_id": 1},
+                            {"action_type": "output", "port": 2},
+                        ],
+                    }
+                ],
+            },
+        },
+    ]
+
+    expected_hop_flows = [
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 2, "dl_vlan": 1, "dl_type": 2048, "nw_proto": 6},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "set_vlan", "vlan_id": 1},
+                            {"action_type": "output", "port": 3},
+                        ],
+                    }
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 2, "dl_vlan": 1, "dl_type": 2048, "nw_proto": 17},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "set_vlan", "vlan_id": 1},
+                            {"action_type": "output", "port": 3},
+                        ],
+                    }
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 3, "dl_vlan": 1, "dl_type": 2048, "nw_proto": 6},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "set_vlan", "vlan_id": 1},
+                            {"action_type": "output", "port": 2},
+                        ],
+                    }
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 3, "dl_vlan": 1, "dl_type": 2048, "nw_proto": 17},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "set_vlan", "vlan_id": 1},
+                            {"action_type": "output", "port": 2},
+                        ],
+                    }
+                ],
+            },
+        },
+    ]
+
+    expected_uni_z_sink_flows = [
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 2, "dl_vlan": 1, "dl_type": 2048, "nw_proto": 6},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "output", "port": 5},
+                        ],
+                    }
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 2, "dl_vlan": 1, "dl_type": 2048, "nw_proto": 17},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "output", "port": 5},
+                        ],
+                    }
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 6, "dl_vlan": 1},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [{"action_type": "send_report"}],
+                    },
+                    {"instruction_type": "goto_table", "table_id": 2},
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 6, "dl_vlan": 1},
+                "table_id": 2,
+                "table_group": "base",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "pop_int"},
+                            {"action_type": "pop_vlan"},
+                            {"action_type": "output", "port": 1},
+                        ],
+                    }
+                ],
+            }
+        },
+    ]
+
+    expected_uni_a_sink_flows = [
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 3, "dl_vlan": 1, "dl_type": 2048, "nw_proto": 6},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "output", "port": 5},
+                        ],
+                    }
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 3, "dl_vlan": 1, "dl_type": 2048, "nw_proto": 17},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20100,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "add_int_metadata"},
+                            {"action_type": "output", "port": 5},
+                        ],
+                    }
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 6, "dl_vlan": 1},
+                "table_id": 0,
+                "table_group": "evpl",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [{"action_type": "send_report"}],
+                    },
+                    {"instruction_type": "goto_table", "table_id": 2},
+                ],
+            },
+        },
+        {
+            "flow": {
+                "owner": "telemetry_int",
+                "cookie": int(0xA816A76AE61B2F46),
+                "match": {"in_port": 6, "dl_vlan": 1},
+                "table_id": 2,
+                "table_group": "base",
+                "priority": 20000,
+                "idle_timeout": 0,
+                "hard_timeout": 0,
+                "instructions": [
+                    {
+                        "instruction_type": "apply_actions",
+                        "actions": [
+                            {"action_type": "pop_int"},
+                            {"action_type": "pop_vlan"},
+                            {"action_type": "output", "port": 1},
+                        ],
+                    }
+                ],
+            },
+        },
+    ]
+
+    expected_flows = (
+        expected_uni_a_source_flows
+        + expected_uni_z_source_flows
+        + expected_hop_flows
+        + expected_uni_z_sink_flows
+        + expected_uni_a_sink_flows
+    )
+
+    for i, flow in enumerate(flows):
+        assert (i, flow["flow"]) == (i, expected_flows[i]["flow"])

--- a/tests/unit/test_flow_builder_intra_evc.py
+++ b/tests/unit/test_flow_builder_intra_evc.py
@@ -13,7 +13,22 @@ from kytos.core.common import EntityStatus
 def test_build_int_flows_intra_evpl(
     evcs_data, intra_evc_evpl_flows_data, monkeypatch
 ) -> None:
-    """Test build INT flows intra EVPL."""
+    """Test build INT flows intra EVPL.
+
+                            +--------+
+                            |        |
+                         10 |      11|
+                   +--------+--------v--+
+                   |                    | 20
+                1  |                    +-----+
+     --------------+                    |     |
+        (vlan 200) |                    |     |
+                   |      sw1           |     |
+               2   |                    |21   |
+    ---------------+                    <-----+
+        (vlan 200) |                    |
+                   +--------------------+
+    """
     controller = get_controller_mock()
     int_manager = INTManager(controller)
     get_proxy_port_or_raise = MagicMock()
@@ -318,7 +333,22 @@ def test_build_int_flows_intra_evpl(
 def test_build_int_flows_intra_epl(
     evcs_data, intra_evc_epl_flows_data, monkeypatch
 ) -> None:
-    """Test build INT flows intra EPL."""
+    """Test build INT flows intra EPL.
+
+                            +--------+
+                            |        |
+                         10 |      11|
+                   +--------+--------v--+
+                   |                    | 20
+                1  |                    +-----+
+     --------------+                    |     |
+                   |                    |     |
+                   |      sw1           |     |
+               2   |                    |21   |
+    ---------------+                    <-----+
+                   |                    |
+                   +--------------------+
+    """
     controller = get_controller_mock()
     int_manager = INTManager(controller)
     get_proxy_port_or_raise = MagicMock()


### PR DESCRIPTION
Closes #52 
Closes #25 

This PR is on top of #51 

### Summary

- Fixed inter EVC hop flows cookie value
- No need to update the changelog this NApp hasn't been released yet

### Local Tests

- Covered with unit tests using this topology and collected the stored flows:

```
               +----+                                              +----+
              5|    |6                                            5|    |6
           +---+----v---+            +------------+           +----+----v---+
        1  |            |            |            |           |             |1
    -------+            |3         2 |            |3        2 |             +-------
     vlan  |     s1     +------------+    s2      +-----------+    s3       | vlan
     101   |            |            |            |           |             | 102
           |            |            |            |           |             |
           +------------+            +------------+           +-------------+
```

### End-to-End Tests

N/A yet