### PR TITLE
feat: added v1 openapi.yml spec

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,14 +95,14 @@ class Main(KytosNApp):
             evcs = {k: v for k, v in evcs.items() if not utils.has_int_enabled(v)}
             if not evcs:
                 # There's no non-INT EVCs to get enabled.
-                return JSONResponse({})
+                return JSONResponse(list(evcs.keys()))
 
         try:
             await self.int_manager.enable_int(evcs, force)
         except (EVCNotFound, FlowsNotFound, ProxyPortNotFound) as exc:
             raise HTTPException(404, detail=str(exc))
         except (EVCHasINT, ProxyPortStatusNotUP) as exc:
-            raise HTTPException(400, detail=str(exc))
+            raise HTTPException(409, detail=str(exc))
         except RetryError as exc:
             exc_error = str(exc.last_attempt.exception())
             log.error(exc_error)
@@ -112,7 +112,7 @@ class Main(KytosNApp):
             log.error(exc_error)
             raise HTTPException(500, detail=exc_error)
 
-        return JSONResponse({}, status_code=201)
+        return JSONResponse(list(evcs.keys()), status_code=201)
 
     @rest("v1/evc/disable", methods=["POST"])
     async def disable_telemetry(self, request: Request) -> JSONResponse:
@@ -146,14 +146,14 @@ class Main(KytosNApp):
             evcs = {k: v for k, v in evcs.items() if utils.has_int_enabled(v)}
             if not evcs:
                 # There's no INT EVCs to get disabled.
-                return JSONResponse({})
+                return JSONResponse(list(evcs.keys()))
 
         try:
             await self.int_manager.disable_int(evcs, force)
         except EVCNotFound as exc:
             raise HTTPException(404, detail=str(exc))
         except EVCHasNoINT as exc:
-            raise HTTPException(400, detail=str(exc))
+            raise HTTPException(409, detail=str(exc))
         except RetryError as exc:
             exc_error = str(exc.last_attempt.exception())
             log.error(exc_error)
@@ -163,7 +163,7 @@ class Main(KytosNApp):
             log.error(exc_error)
             raise HTTPException(500, detail=exc_error)
 
-        return JSONResponse({})
+        return JSONResponse(list(evcs.keys()))
 
     @rest("v1/evc")
     def get_evcs(self, _request: Request) -> JSONResponse:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,113 @@
+openapi: 3.0.0
+info:
+  version: v1
+  title: In-band Network Telemetry (INT) for EVCs
+  description: NApp to deploy In-band Network Telemetry (INT) for EVCs
+servers:
+  - url: /api/kytos/telemetry_int
+paths:
+  /v1/evc/enable:
+    post:
+      summary: Enable INT on EVCs
+      operationId: enable_evc
+      requestBody:
+        description: Enable INT on EVCs. If the list of evc_ids is empty, it will try to enable on non-INT EVCs.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                evc_ids:
+                  type: array
+                  items:
+                    type: string
+                force:
+                  type: boolean
+                  description: Force INT to get enabled again. It will enable even if the EVC already has INT or if a ProxyPort isn't UP.
+                  default: false
+      responses:
+        '201':
+          description: INT enabled on EVCs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          description: Invalid request payload
+        '409':
+          description: Conflict resource state. For instance, when an EVC already has INT or a ProxyPort status isn't UP.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResp'
+        '404':
+          description: Dependent resource (EVC, flows or ProxyPort) not found 
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResp'
+        '500':
+          description: Internal Server Error
+        '503':
+          description: Service unavailable
+  /v1/evc/disable:
+    post:
+      summary: Disable INT on EVCs
+      operationId: disable_evc
+      requestBody:
+        description: Disable INT on EVCs. If the list of evc_ids is empty, it will try to disable on all INT EVCs.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                evc_ids:
+                  type: array
+                  items:
+                    type: string
+                force:
+                  type: boolean
+                  description: Force INT to get disabled again. It will try to disable even if the EVC isn't found or it doesn't have INT.
+                  default: false
+      responses:
+        '201':
+          description: INT disabled on EVCs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          description: Invalid request payload
+        '409':
+          description: Conflict resource state. For instance, when an EVC already has INT or a ProxyPort status isn't UP.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResp'
+        '404':
+          description: Dependent resource (EVC, flows or ProxyPort) not found 
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResp'
+        '500':
+          description: Internal Server Error
+        '503':
+          description: Service unavailable
+
+
+components:
+  schemas:
+    ErrResp: # Can be referenced via '#/components/schemas/ErrResp'
+      type: object
+      properties:
+        description:
+          type: string
+        code:
+          type: number


### PR DESCRIPTION
Closes #6 

### Summary

- Added v1 openapi.yml spec for endpoints `POST /v1/evc/enable` and `POST /v1/evc/disable`
- Updated responses and status code on endpoints accordingly to spec
- This NApp doesn't have a changelog yet

### Local Tests

- Rendered the API spec:

![20231003_123548](https://github.com/kytos-ng/telemetry_int/assets/1010796/65b08b23-a829-4cd7-b617-7ce74fd3a2d9)


- Enabled and disabled and exercised the expected status codes

```
kytos $> 2023-10-03 12:31:02,006 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:33184 - "GET /api/kytos/mef_eline/v2/evc/9093192378aa4d HTTP/1.1" 200        
2023-10-03 12:31:02,007 - INFO [kytos.napps.kytos/telemetry_int] [int.py:79:enable_int] (MainThread) Enabling INT on EVC ids: ['9093192378aa4d'], force: False
2023-10-03 12:31:02,017 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:33198 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTT
P/1.1" 200
2023-10-03 12:31:02,041 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:33210 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-10-03 12:31:02,055 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:33172 - "POST /api/kytos/telemetry_int/v1/evc/enable/ HTTP/1.1" 201
2023-10-03 12:31:07,692 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59648 - "GET /api/kytos/mef_eline/v2/evc/9093192378aa4d HTTP/1.1" 200
2023-10-03 12:31:07,693 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59632 - "POST /api/kytos/telemetry_int/v1/evc/enable/ HTTP/1.1" 409
2023-10-03 12:31:09,368 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59650 - "GET /api/kytos/mef_eline/v2/evc/9093192378aa4d HTTP/1.1" 200
2023-10-03 12:31:09,369 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59632 - "POST /api/kytos/telemetry_int/v1/evc/enable/ HTTP/1.1" 409
2023-10-03 12:31:19,181 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:55232 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200
2023-10-03 12:31:19,182 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:55226 - "POST /api/kytos/telemetry_int/v1/evc/enable/ HTTP/1.1" 200
2023-10-03 12:31:20,115 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:55246 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200
2023-10-03 12:31:20,117 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:55226 - "POST /api/kytos/telemetry_int/v1/evc/enable/ HTTP/1.1" 200
2023-10-03 12:31:23,562 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:58668 - "GET /api/kytos/mef_eline/v2/evc/9093192378aa4d HTTP/1.1" 200
2023-10-03 12:31:23,563 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:55226 - "POST /api/kytos/telemetry_int/v1/evc/enable/ HTTP/1.1" 409
2023-10-03 12:31:35,032 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42654 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 400
2023-10-03 12:31:35,979 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42672 - "GET /api/kytos/flow_manager/v2/stored_flows/?state=installed HTTP/1.1" 200
2023-10-03 12:31:35,982 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42658 - "PUT /api/amlight/sdntrace_cp/v1/traces HTTP/1.1" 200
2023-10-03 12:31:35,983 - INFO [kytos.napps.kytos/mef_eline] [main.py:118:execute_consistency] (mef_eline) EVC(9093192378aa4d, evpl) enabled but inactive - activating
2023-10-03 12:31:38,804 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42674 - "GET /api/kytos/mef_eline/v2/evc/9093192378aa4dx HTTP/1.1" 404
2023-10-03 12:31:38,806 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42654 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 404
2023-10-03 12:31:42,330 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46202 - "GET /api/kytos/mef_eline/v2/evc/9093192378aa4d HTTP/1.1" 200
2023-10-03 12:31:42,332 - INFO [kytos.napps.kytos/telemetry_int] [int.py:46:disable_int] (MainThread) Disabling INT on EVC ids: ['9093192378aa4d'], force: False
2023-10-03 12:31:42,342 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46212 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending&coo
kie_range=12146369931196803661&cookie_range=12146369931196803661 HTTP/1.1" 200
2023-10-03 12:31:42,354 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46220 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-10-03 12:31:42,355 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42654 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 200
2023-10-03 12:31:44,814 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46232 - "GET /api/kytos/mef_eline/v2/evc/9093192378aa4d HTTP/1.1" 200
2023-10-03 12:31:44,815 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42654 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 409
2023-10-03 12:31:48,985 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46236 - "GET /api/kytos/mef_eline/v2/evc/?archived=false HTTP/1.1" 200
2023-10-03 12:31:48,986 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42654 - "POST /api/kytos/telemetry_int/v1/evc/disable/ HTTP/1.1" 200
kytos $>                                                                                                                                                                                  

```


### End-to-End Tests

N/A yet
