### PR TITLE
feat: added openapi spec validations on endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ Napp to deploy In-band Network Telemetry over Ethernet Virtual Circuits
 """
 
 import asyncio
+import pathlib
 from datetime import datetime
 
 import napps.kytos.telemetry_int.kytos_api_helper as api
@@ -12,7 +13,7 @@ from napps.kytos.telemetry_int import settings, utils
 from tenacity import RetryError
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
-from kytos.core.helpers import alisten_to
+from kytos.core.helpers import alisten_to, avalidate_openapi_request, load_spec
 from kytos.core.rest_api import HTTPException, JSONResponse, Request, aget_json_or_400
 
 from .exceptions import (
@@ -34,6 +35,8 @@ class Main(KytosNApp):
 
     This class is the entry point for this NApp.
     """
+
+    spec = load_spec(pathlib.Path(__file__).parent / "openapi.yml")
 
     def setup(self):
         """Replace the '__init__' method for the KytosNApp subclass.
@@ -68,6 +71,7 @@ class Main(KytosNApp):
 
         If a list of evc_ids is empty, it'll enable on non-INT EVCs.
         """
+        await avalidate_openapi_request(self.spec, request)
 
         try:
             content = await aget_json_or_400(request)
@@ -120,6 +124,8 @@ class Main(KytosNApp):
 
         If a list of evc_ids is empty, it'll disable on all INT EVCs.
         """
+        await avalidate_openapi_request(self.spec, request)
+
         try:
             content = await aget_json_or_400(request)
             evc_ids = content["evc_ids"]


### PR DESCRIPTION
Closes #54 

This PR is on top of PR #6 

### Summary

- Added openapi spec validations on endpoints
- This NApp doesn't have a changelog yet

### Local Tests

```
❯ echo '{}' | http http://localhost:8181/api/kytos/telemetry_int/v1/evc/enable                                                                                                  [NORMAL] 
HTTP/1.1 400 Bad Request
content-length: 48
content-type: application/json
date: Tue, 03 Oct 2023 17:32:50 GMT
server: uvicorn

{
    "code": 400,
    "description": "Invalid payload: {}"
}



❯ echo '{"evc_ids": 1}' | http http://localhost:8181/api/kytos/telemetry_int/v1/evc/enable
HTTP/1.1 400 Bad Request
content-length: 116
content-type: application/json
date: Tue, 03 Oct 2023 17:33:03 GMT
server: uvicorn

{
    "code": 400,
    "description": "The request body contains invalid API data. 1 is not of type 'array' for field evc_ids."
}


❯ echo '{"evc_ids": [1]}' | http http://localhost:8181/api/kytos/telemetry_int/v1/evc/disable
HTTP/1.1 400 Bad Request
content-length: 119
content-type: application/json
date: Tue, 03 Oct 2023 17:33:50 GMT
server: uvicorn

{
    "code": 400,
    "description": "The request body contains invalid API data. 1 is not of type 'string' for field evc_ids/0."
}
```

### End-to-End Tests

N/A yet
