### PR TITLE
feat|refactor: added `GET /v1/evc` on openapi.yml 

### DIFF
--- a/kytos_api_helper.py
+++ b/kytos_api_helper.py
@@ -25,11 +25,15 @@ from kytos.core.retry import before_sleep
     before_sleep=before_sleep,
     retry=retry_if_exception_type((httpx.RequestError, httpx.HTTPStatusError)),
 )
-async def get_evcs() -> dict:
+async def get_evcs(**kwargs) -> dict:
     """Get EVCs."""
     archived = "false"
     async with httpx.AsyncClient(base_url=settings.mef_eline_api) as client:
-        response = await client.get(f"/evc/?archived={archived}", timeout=10)
+        endpoint = f"/evc/?archived={archived}"
+        if kwargs:
+            query_args = [f"{k}={v}" for k, v in kwargs.items()]
+            endpoint = f"{endpoint}&{'&'.join(query_args)}"
+        response = await client.get(endpoint, timeout=10)
         if response.is_server_error:
             raise httpx.RequestError(response.text)
         if not response.is_success:

--- a/main.py
+++ b/main.py
@@ -176,11 +176,7 @@ class Main(KytosNApp):
         """REST to return the list of EVCs with INT enabled"""
         try:
             evcs = await api.get_evcs()
-            evcs = {
-                k: v
-                for k, v in evcs.items()
-                if utils.has_int_enabled(v)
-            }
+            evcs = {k: v for k, v in evcs.items() if utils.has_int_enabled(v)}
             return JSONResponse(evcs)
         except RetryError as exc:
             exc_error = str(exc.last_attempt.exception())

--- a/main.py
+++ b/main.py
@@ -175,8 +175,7 @@ class Main(KytosNApp):
     async def get_evcs(self, _request: Request) -> JSONResponse:
         """REST to return the list of EVCs with INT enabled"""
         try:
-            evcs = await api.get_evcs()
-            evcs = {k: v for k, v in evcs.items() if utils.has_int_enabled(v)}
+            evcs = await api.get_evcs(**{"metadata.telemetry.enabled": "true"})
             return JSONResponse(evcs)
         except RetryError as exc:
             exc_error = str(exc.last_attempt.exception())

--- a/openapi.yml
+++ b/openapi.yml
@@ -6,10 +6,21 @@ info:
 servers:
   - url: /api/kytos/telemetry_int
 paths:
+  /v1/evc:
+    get:
+      summary: List all INT enabled EVCs
+      operationId: list_evcs
+      responses:
+        '200':
+          description: List all INT enabled EVCs. The schema object is the same as mef_eline '#/components/schemas/Circuit'
+          content:
+            application/json:
+              schema:
+                type: object
   /v1/evc/enable:
     post:
       summary: Enable INT on EVCs
-      operationId: enable_evc
+      operationId: enable_evcs
       requestBody:
         description: Enable INT on EVCs. If the list of evc_ids is empty, it will try to enable on non-INT EVCs.
         required: true
@@ -56,7 +67,7 @@ paths:
   /v1/evc/disable:
     post:
       summary: Disable INT on EVCs
-      operationId: disable_evc
+      operationId: disable_evcs
       requestBody:
         description: Disable INT on EVCs. If the list of evc_ids is empty, it will try to disable on all INT EVCs.
         required: true

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -75,28 +75,25 @@ class TestMain:
 
     async def test_get_enabled_evcs(self, monkeypatch) -> None:
         """Test get enabled evcs."""
-        api_mock, flow1, flow2 = AsyncMock(), MagicMock(), MagicMock()
-        flow1.cookie = 0xA800000000000001
-        flow2.cookie = 0xA800000000000002
+        api_mock, flow = AsyncMock(), MagicMock()
+        flow.cookie = 0xA800000000000001
         monkeypatch.setattr(
             "napps.kytos.telemetry_int.main.api",
             api_mock,
         )
 
-        evc1_id = utils.get_id_from_cookie(flow1.cookie)
-        evc2_id = utils.get_id_from_cookie(flow2.cookie)
+        evc_id = utils.get_id_from_cookie(flow.cookie)
         api_mock.get_evcs.return_value = {
-            evc1_id: {"metadata": {"telemetry": {"enabled": False}}},
-            evc2_id: {"metadata": {"telemetry": {"enabled": True}}}
+            evc_id: {"metadata": {"telemetry": {"enabled": True}}},
         }
 
         endpoint = f"{self.base_endpoint}/evc"
         response = await self.api_client.get(endpoint)
+        assert api_mock.get_evcs.call_args[1] == {"metadata.telemetry.enabled": "true"}
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
-        assert evc1_id not in data
-        assert evc2_id in data
+        assert evc_id in data
 
     async def test_on_flow_mod_error(self, monkeypatch) -> None:
         """Test on_flow_mod_error."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -73,6 +73,31 @@ class TestMain:
         assert response.status_code == 200
         assert response.json() == [evc_id]
 
+    async def test_get_enabled_evcs(self, monkeypatch) -> None:
+        """Test get enabled evcs."""
+        api_mock, flow1, flow2 = AsyncMock(), MagicMock(), MagicMock()
+        flow1.cookie = 0xA800000000000001
+        flow2.cookie = 0xA800000000000002
+        monkeypatch.setattr(
+            "napps.kytos.telemetry_int.main.api",
+            api_mock,
+        )
+
+        evc1_id = utils.get_id_from_cookie(flow1.cookie)
+        evc2_id = utils.get_id_from_cookie(flow2.cookie)
+        api_mock.get_evcs.return_value = {
+            evc1_id: {"metadata": {"telemetry": {"enabled": False}}},
+            evc2_id: {"metadata": {"telemetry": {"enabled": True}}}
+        }
+
+        endpoint = f"{self.base_endpoint}/evc"
+        response = await self.api_client.get(endpoint)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert evc1_id not in data
+        assert evc2_id in data
+
     async def test_on_flow_mod_error(self, monkeypatch) -> None:
         """Test on_flow_mod_error."""
         api_mock, flow = AsyncMock(), MagicMock()

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,6 @@ from napps.kytos.telemetry_int import settings
 from kytos.core import Controller
 
 from .exceptions import FlowsNotFound, PriorityOverflow, ProxyPortNotFound
-from .kytos_api_helper import get_evcs
 from .kytos_api_helper import get_stored_flows as _get_stored_flows
 from .proxy_port import ProxyPort
 
@@ -18,17 +17,6 @@ async def get_found_stored_flows(cookies: list[int] = None) -> dict[int, list[di
         if not flows:
             raise FlowsNotFound(get_id_from_cookie(cookie))
     return stored_flows
-
-
-def get_evc_with_telemetry() -> dict:
-    """Retrieve the list of EVC IDs and list those with
-    metadata {"telemetry": {"enabled": true}}"""
-
-    evc_ids = {"evcs_with_telemetry": []}
-    for evc in get_evcs().values():
-        if has_int_enabled(evc):
-            evc_ids["evcs_with_telemetry"].append(evc["id"])
-    return evc_ids
 
 
 def has_int_enabled(evc: dict) -> bool:


### PR DESCRIPTION
Closes #59 

This PR is on top of PR #56 

### Summary

- Added `GET /v1/evc` on openapi.yml (the response content follows mef_eline content)
- Covered with unit test
- Changelog not needed to update this NApp hasn't been released yet

### Local Tests

- Enabled INT on an EVC, listed it, then disabled it and made sure that `v1/evc` wouldn't list it:

```
❯ http http://localhost:8181/api/kytos/telemetry_int/v1/evc | jq               
{
  "9093192378aa4d": {
    "active": false,
    "archived": false,
    "backup_path": [],
    "bandwidth": 0,
    "circuit_scheduler": [],
    "current_path": [
      {
        "id": "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07",
        "endpoint_a": {
          "id": "00:00:00:00:00:00:00:01:4",
          "name": "s1-eth4",
          "port_number": 4,
          "mac": "92:09:64:f9:31:36",
          "switch": "00:00:00:00:00:00:00:01",
          "type": "interface",
          "nni": true,
          "uni": false,
          "speed": 1250000000.0,
          "metadata": {},
          "lldp": true,
          "active": false,
          "enabled": true,
          "status": "DOWN",
          "status_reason": [
            "deactivated"
          ],
          "link": "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07"
        },
        "endpoint_b": {
          "id": "00:00:00:00:00:00:00:03:3",
          "name": "s3-eth3",
          "port_number": 3,
          "mac": "4e:8a:bf:9d:b4:ba",
          "switch": "00:00:00:00:00:00:00:03",
          "type": "interface",
          "nni": true,
          "uni": false,
          "speed": 1250000000.0,
          "metadata": {},
          "lldp": true,
          "active": false,
          "enabled": true,
          "status": "DOWN",
          "status_reason": [
            "deactivated"
          ],
          "link": "c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07"
        },
        "metadata": {
          "s_vlan": {
            "tag_type": 1,
            "value": 1
          }
        },
        "active": false,
        "enabled": true,
        "status": "DOWN",
        "status_reason": [
          "deactivated"
        ]
      }
    ],
    "dynamic_backup_path": true,
    "enabled": true,
    "failover_path": [
      {
        "id": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
        "endpoint_a": {
          "id": "00:00:00:00:00:00:00:01:3",
          "name": "s1-eth3",
          "port_number": 3,
          "mac": "ce:cb:4b:8b:7e:b2",
          "switch": "00:00:00:00:00:00:00:01",
          "type": "interface",
          "nni": true,
          "uni": false,
          "speed": 1250000000.0,
          "metadata": {},
          "lldp": true,
          "active": false,
          "enabled": true,
          "status": "DOWN",
          "status_reason": [
            "deactivated"
          ],
          "link": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0"
        },
        "endpoint_b": {
          "id": "00:00:00:00:00:00:00:02:2",
          "name": "s2-eth2",
          "port_number": 2,
          "mac": "82:6e:ca:7b:a3:fd",
          "switch": "00:00:00:00:00:00:00:02",
          "type": "interface",
          "nni": true,
          "uni": false,
          "speed": 1250000000.0,
          "metadata": {},
          "lldp": true,
          "active": false,
          "enabled": true,
          "status": "DOWN",
          "status_reason": [
            "deactivated"
          ],
          "link": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0"
        },
        "metadata": {
          "s_vlan": {
            "tag_type": 1,
            "value": 1
          }
        },
        "active": false,
        "enabled": true,
        "status": "DOWN",
        "status_reason": [
          "deactivated"
        ]
      },
      {
        "id": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
        "endpoint_a": {
          "id": "00:00:00:00:00:00:00:02:3",
          "name": "s2-eth3",
          "port_number": 3,
          "mac": "e2:28:35:3d:eb:d9",
          "switch": "00:00:00:00:00:00:00:02",
          "type": "interface",
          "nni": true,
          "uni": false,
          "speed": 1250000000.0,
          "metadata": {},
          "lldp": true,
          "active": false,
          "enabled": true,
          "status": "DOWN",
          "status_reason": [
            "deactivated"
          ],
          "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30"
        },
        "endpoint_b": {
          "id": "00:00:00:00:00:00:00:03:2",
          "name": "s3-eth2",
          "port_number": 2,
          "mac": "a6:ad:3b:3f:88:de",
          "switch": "00:00:00:00:00:00:00:03",
          "type": "interface",
          "nni": true,
          "uni": false,
          "speed": 1250000000.0,
          "metadata": {},
          "lldp": true,
          "active": false,
          "enabled": true,
          "status": "DOWN",
          "status_reason": [
            "deactivated"
          ],
          "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30"
        },
        "metadata": {
          "s_vlan": {
            "tag_type": 1,
            "value": 1
          }
        },
        "active": false,
        "enabled": true,
        "status": "DOWN",
        "status_reason": [
          "deactivated"
        ]
      }
    ],
    "id": "9093192378aa4d",
    "metadata": {
      "telemetry": {
        "enabled": true,
        "status": "UP",
        "status_reason": [],
        "status_updated_at": "2023-10-05T13:25:27"
      }
    },
    "name": "evpl",
    "primary_path": [],
    "service_level": 6,
    "uni_a": {
      "tag": {
        "tag_type": 1,
        "value": 101
      },
      "interface_id": "00:00:00:00:00:00:00:01:1"
    },
    "uni_z": {
      "tag": {
        "tag_type": 1,
        "value": 102
      },
      "interface_id": "00:00:00:00:00:00:00:03:1"
    },
    "sb_priority": null,
    "execution_rounds": 0,
    "owner": null,
    "queue_id": null,
    "primary_constraints": {
      "mandatory_metrics": {
        "ownership": "blue"
      }
    },
    "secondary_constraints": {
      "mandatory_metrics": {
        "ownership": "blue"
      }
    },
    "primary_links": [],
    "backup_links": [],
    "start_date": "2023-10-03T15:21:34",
    "creation_time": "2023-10-03T15:21:34",
    "request_time": "2023-10-03T15:21:34",
    "end_date": null,
    "flow_removed_at": null,
    "updated_at": "2023-10-05T13:40:33"
  }
}

 
❯ echo '{"evc_ids": []}' | http http://localhost:8181/api/kytos/telemetry_int/v1/evc/disable
HTTP/1.1 200 OK
content-length: 18
content-type: application/json
date: Thu, 05 Oct 2023 13:41:31 GMT
server: uvicorn

[
    "9093192378aa4d"
]



❯ http http://localhost:8181/api/kytos/telemetry_int/v1/evc | jq                            
{}
```

### End-to-End Tests

N/A yet