### PR TITLE
feat: validate intra EVC UNIs must use different proxy ports

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -42,6 +42,13 @@ class ProxyPortStatusNotUP(ProxyPortError):
     """ProxyPortStatusNotUP."""
 
 
+class ProxyPortSameSourceIntraEVC(ProxyPortError):
+    """ProxyPortSameSourceIntraEVC.
+
+    Intra EVC UNIs must use different proxy ports.
+    """
+
+
 class EVCHasNoINT(EVCError):
     """Exception in case the EVC doesn't have INT enabled."""
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from .exceptions import (
     EVCNotFound,
     FlowsNotFound,
     ProxyPortNotFound,
+    ProxyPortSameSourceIntraEVC,
     ProxyPortStatusNotUP,
     UnrecoverableError,
 )
@@ -105,7 +106,7 @@ class Main(KytosNApp):
             await self.int_manager.enable_int(evcs, force)
         except (EVCNotFound, FlowsNotFound, ProxyPortNotFound) as exc:
             raise HTTPException(404, detail=str(exc))
-        except (EVCHasINT, ProxyPortStatusNotUP) as exc:
+        except (EVCHasINT, ProxyPortStatusNotUP, ProxyPortSameSourceIntraEVC) as exc:
             raise HTTPException(409, detail=str(exc))
         except RetryError as exc:
             exc_error = str(exc.last_attempt.exception())


### PR DESCRIPTION
Closes #39 
### Summary

- validate intra EVC UNIs must use different proxy ports
- this NApps hasn't been released yet, no need to update changelog

### Local Tests

```
kytos $> 2023-10-10 13:04:03,459 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:34960 - "GET /api/kytos/mef_eline/v2/evc/b45f387345094d HTTP/1.1" 200       
2023-10-10 13:04:03,460 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:34954 - "POST /api/kytos/telemetry_int/v1/evc/enable HTTP/1.1" 409
```

- Tried to enable INT on an intra EVC using same proxy ports:

```

{
    "description": "EVC b45f387345094d intra EVC UNIs must use different proxy ports",
    "code": 409
}
```

- Solved the conflict and finally enabled:

```
2023-10-10 13:04:57,556 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59524 - "POST /api/kytos/topology/v3/interfaces/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01
%3A02/metadata HTTP/1.1" 201
2023-10-10 13:05:01,971 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59546 - "GET /api/kytos/mef_eline/v2/evc/b45f387345094d HTTP/1.1" 200
2023-10-10 13:05:01,972 - INFO [kytos.napps.kytos/telemetry_int] [int.py:80:enable_int] (MainThread) Enabling INT on EVC ids: ['b45f387345094d'], force: False
2023-10-10 13:05:01,983 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59552 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HT
TP/1.1" 200
2023-10-10 13:05:01,997 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59566 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-10-10 13:05:01,999 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:59538 - "POST /api/kytos/telemetry_int/v1/evc/enable HTTP/1.1" 201

```

### End-to-End Tests

N/A
