### PR TITLE
feat: integration with `of_multi_table` supporting `evpl` and `epl` table groups on table 2 and 3 by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,23 @@ Requirements
 - `kytos/noviflow <https://github.com/kytos-ng/noviflow>`_
 - `kytos/mef_eline <https://github.com/kytos-ng/mef_eline>`_
 
+Events
+======
+
+Subscribed
+----------
+- ``kytos/of_multi_table.enable_table``
+- ``kytos/mef_eline.deleted``
+- ``kytos/flow_manager.flow.error``
+
+Published
+---------
+
+kytos/of_lldp.enable_table
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A response from the ``kytos/of_multi_table.enable_table`` event to confirm table settings.
+
 General Information
 ===================
 

--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -11,261 +11,285 @@ from napps.kytos.telemetry_int.exceptions import FlowsNotFound
 from napps.kytos.telemetry_int import settings
 
 
-def build_int_flows(
-    evcs: dict[str, dict], stored_flows: dict[int, list[dict]]
-) -> dict[int, list[dict]]:
-    """build INT flows.
+class FlowBuilder:
+    """FlowBuilder."""
 
-    It'll map and create all INT flows needed, for now since each EVC
-    is bidirectional, it'll provision bidirectionally too. In the future,
-    if mef_eline supports unidirectional EVC, it'll follow suit accordingly.
-    """
-    flows_per_cookie: dict[int, list[dict]] = defaultdict(list)
-    for evc_id, evc in evcs.items():
-        for flow in itertools.chain(
-            _build_int_source_flows("uni_a", evc, stored_flows),
-            _build_int_source_flows("uni_z", evc, stored_flows),
-            _build_int_hop_flows(evc, stored_flows),
-            _build_int_sink_flows("uni_z", evc, stored_flows),
-            _build_int_sink_flows("uni_a", evc, stored_flows),
-        ):
-            cookie = utils.get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
-            flows_per_cookie[cookie].append(flow)
-    return flows_per_cookie
+    def __init__(self):
+        """Constructor of FlowBuilder."""
+        self.table_group = {"evpl": 2, "epl": 3}
 
+    def build_int_flows(
+        self,
+        evcs: dict[str, dict],
+        stored_flows: dict[int, list[dict]],
+    ) -> dict[int, list[dict]]:
+        """build INT flows.
 
-def _build_int_source_flows(
-    uni_src_key: Literal["uni_a", "uni_z"],
-    evc: dict,
-    stored_flows: dict[int, list[dict]],
-) -> list[dict]:
-    """Build INT source flows.
+        It'll map and create all INT flows needed, for now since each EVC
+        is bidirectional, it'll provision bidirectionally too. In the future,
+        if mef_eline supports unidirectional EVC, it'll follow suit accordingly.
+        """
+        flows_per_cookie: dict[int, list[dict]] = defaultdict(list)
+        for evc_id, evc in evcs.items():
+            for flow in itertools.chain(
+                self._build_int_source_flows("uni_a", evc, stored_flows),
+                self._build_int_source_flows("uni_z", evc, stored_flows),
+                self._build_int_hop_flows(evc, stored_flows),
+                self._build_int_sink_flows("uni_z", evc, stored_flows),
+                self._build_int_sink_flows("uni_a", evc, stored_flows),
+            ):
+                cookie = utils.get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
+                flows_per_cookie[cookie].append(flow)
+        return flows_per_cookie
 
-    At the INT source, one flow becomes 3: one for UDP on table 0,
-    one for TCP on table 0, and one on table 2
-    On table 0, we use just new instructions: push_int and goto_table
-    On table 2, we add add_int_metadata before the original actions
-    INT flows will have higher priority.
-    """
-    new_flows = []
-    new_int_flow_tbl_0_tcp = {}
-    src_uni = evc[uni_src_key]
+    def _build_int_source_flows(
+        self,
+        uni_src_key: Literal["uni_a", "uni_z"],
+        evc: dict,
+        stored_flows: dict[int, list[dict]],
+    ) -> list[dict]:
+        """Build INT source flows.
 
-    # Get the original flows
-    dpid = src_uni["switch"]
-    for flow in stored_flows[utils.get_cookie(evc["id"], settings.MEF_COOKIE_PREFIX)]:
-        if (
-            flow["switch"] == dpid
-            and flow["flow"]["match"]["in_port"] == src_uni["port_number"]
-        ):
-            new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
-            break
+        At the INT source, one flow becomes 3: one for UDP on table 0,
+        one for TCP on table 0, and one on table X (2 for evpl and 3 for epl by default)
+        On table 0, we use just new instructions: push_int and goto_table
+        On table X, we add add_int_metadata before the original actions
+        INT flows will have higher priority.
+        """
+        new_flows = []
+        new_int_flow_tbl_0_tcp = {}
+        src_uni = evc[uni_src_key]
 
-    if not new_int_flow_tbl_0_tcp:
-        raise FlowsNotFound(evc["id"])
-
-    utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
-    utils.set_new_cookie(new_int_flow_tbl_0_tcp)
-    utils.set_owner(new_int_flow_tbl_0_tcp)
-
-    # Deepcopy to use for table 2 later
-    new_int_flow_tbl_2 = copy.deepcopy(new_int_flow_tbl_0_tcp)
-
-    # Prepare TCP Flow for Table 0
-    new_int_flow_tbl_0_tcp["flow"]["match"]["dl_type"] = settings.IPv4
-    new_int_flow_tbl_0_tcp["flow"]["match"]["nw_proto"] = settings.TCP
-    utils.set_priority(new_int_flow_tbl_0_tcp)
-
-    # The flow_manager has two outputs: instructions and actions.
-    instructions = [
-        {
-            "instruction_type": "apply_actions",
-            "actions": [{"action_type": "push_int"}],
-        },
-        {"instruction_type": "goto_table", "table_id": settings.INT_TABLE},
-    ]
-    new_int_flow_tbl_0_tcp["flow"]["instructions"] = instructions
-
-    # Prepare UDP Flow for Table 0. Everything the same as TCP except the nw_proto
-    new_int_flow_tbl_0_udp = copy.deepcopy(new_int_flow_tbl_0_tcp)
-    new_int_flow_tbl_0_udp["flow"]["match"]["nw_proto"] = settings.UDP
-
-    # Prepare Flows for Table 2 - No TCP or UDP specifics
-    new_int_flow_tbl_2["flow"]["table_id"] = settings.INT_TABLE
-    utils.set_table_group(new_int_flow_tbl_2)
-
-    # if intra-switch EVC, then output port should be the dst UNI's source port
-    if utils.is_intra_switch_evc(evc):
-        dst_uni = evc["uni_z" if uni_src_key == "uni_a" else "uni_a"]
-        proxy_port = dst_uni["proxy_port"]
-        for instruction in new_int_flow_tbl_2["flow"]["instructions"]:
-            if instruction["instruction_type"] == "apply_actions":
-                for action in instruction["actions"]:
-                    if action["action_type"] == "output":
-                        # Since this is the INT Source, we use source
-                        # to avoid worrying about single or multi
-                        # home physical loops.
-                        # The choice for destination is at the INT Sink.
-                        action["port"] = proxy_port.source.port_number
-
-                # remove set_vlan action if it exists, this is for
-                # avoding a redundant set_vlan since it'll be set in the egress sink
-                instruction["actions"] = utils.modify_actions(
-                    instruction["actions"], ["set_vlan"], remove=True
-                )
-
-    instructions = utils.add_to_apply_actions(
-        new_int_flow_tbl_2["flow"]["instructions"],
-        new_instruction={"action_type": "add_int_metadata"},
-        position=0,
-    )
-
-    new_int_flow_tbl_2["flow"]["instructions"] = instructions
-
-    new_flows.append(new_int_flow_tbl_0_tcp)
-    new_flows.append(new_int_flow_tbl_0_udp)
-    new_flows.append(new_int_flow_tbl_2)
-
-    return new_flows
-
-
-def _build_int_hop_flows(
-    evc: dict,
-    stored_flows: dict[int, list[dict]],
-) -> list[dict]:
-    """Build INT hop flows.
-
-    At the INT hops, one flow adds two more: one for UDP on table 0,
-    one for TCP on table 0. On table 0, we add 'add_int_metadata'
-    before other actions.
-    """
-
-    new_flows = []
-    excluded_dpids = set([evc["uni_a"]["switch"], evc["uni_z"]["switch"]])
-
-    for flow in stored_flows[utils.get_cookie(evc["id"], settings.MEF_COOKIE_PREFIX)]:
-        if flow["switch"] in excluded_dpids:
-            continue
-        if "match" not in flow["flow"] or "in_port" not in flow["flow"]["match"]:
-            continue
-
-        new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
-        utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
-        utils.set_new_cookie(new_int_flow_tbl_0_tcp)
-        utils.set_owner(new_int_flow_tbl_0_tcp)
-
-        # Prepare TCP Flow
-        new_int_flow_tbl_0_tcp["flow"]["match"]["dl_type"] = settings.IPv4
-        new_int_flow_tbl_0_tcp["flow"]["match"]["nw_proto"] = settings.TCP
-        utils.set_priority(new_int_flow_tbl_0_tcp)
-
-        for instruction in new_int_flow_tbl_0_tcp["flow"]["instructions"]:
-            if instruction["instruction_type"] == "apply_actions":
-                instruction["actions"].insert(0, {"action_type": "add_int_metadata"})
-
-        # Prepare UDP Flow
-        new_int_flow_tbl_0_udp = copy.deepcopy(new_int_flow_tbl_0_tcp)
-        new_int_flow_tbl_0_udp["flow"]["match"]["nw_proto"] = settings.UDP
-
-        new_flows.append(new_int_flow_tbl_0_tcp)
-        new_flows.append(new_int_flow_tbl_0_udp)
-
-    return new_flows
-
-
-def _build_int_sink_flows(
-    uni_dst_key: Literal["uni_a", "uni_z"],
-    evc: dict,
-    stored_flows: dict[int, list[dict]],
-) -> list[dict]:
-    """
-    Build INT sink flows.
-
-    At the INT sink, one flow becomes many:
-    1. Before the proxy, we do add_int_metadata as an INT hop.
-    We need to keep the set_queue
-    2. After the proxy, we do send_report and pop_int and output
-    We only use table 0 for #1.
-    We use table 2 for #2. for pop_int and output
-    """
-    new_flows = []
-    dst_uni = evc[uni_dst_key]
-    proxy_port = dst_uni["proxy_port"]
-    dpid = dst_uni["switch"]
-
-    for flow in stored_flows[utils.get_cookie(evc["id"], settings.MEF_COOKIE_PREFIX)]:
-        # Only consider this sink's dpid flows
-        if flow["switch"] != dpid:
-            continue
-        # Only consider flows coming from NNI interfaces
-        if flow["flow"]["match"]["in_port"] == dst_uni["port_number"]:
-            continue
-
-        new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
+        # Get the original flows
+        dpid = src_uni["switch"]
+        for flow in stored_flows[
+            utils.get_cookie(evc["id"], settings.MEF_COOKIE_PREFIX)
+        ]:
+            if (
+                flow["switch"] == dpid
+                and flow["flow"]["match"]["in_port"] == src_uni["port_number"]
+            ):
+                new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
+                break
 
         if not new_int_flow_tbl_0_tcp:
             raise FlowsNotFound(evc["id"])
 
+        utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
         utils.set_new_cookie(new_int_flow_tbl_0_tcp)
         utils.set_owner(new_int_flow_tbl_0_tcp)
-        utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
 
-        # Save for pos-proxy flows
-        new_int_flow_tbl_0_pos = copy.deepcopy(new_int_flow_tbl_0_tcp)
-        new_int_flow_tbl_2_pos = copy.deepcopy(new_int_flow_tbl_0_tcp)
+        # Deepcopy to use for table X (2 or 3 by default for EVPL or EPL respectively)
+        new_int_flow_tbl_x = copy.deepcopy(new_int_flow_tbl_0_tcp)
 
-        # Prepare TCP Flow for Table 0 PRE proxy
-        if not utils.is_intra_switch_evc(evc):
+        # Prepare TCP Flow for Table 0
+        new_int_flow_tbl_0_tcp["flow"]["match"]["dl_type"] = settings.IPv4
+        new_int_flow_tbl_0_tcp["flow"]["match"]["nw_proto"] = settings.TCP
+        utils.set_priority(new_int_flow_tbl_0_tcp)
+
+        # The flow_manager has two outputs: instructions and actions.
+        table_group = self.table_group
+        new_table_id = table_group[new_int_flow_tbl_x["flow"]["table_group"]]
+        instructions = [
+            {
+                "instruction_type": "apply_actions",
+                "actions": [{"action_type": "push_int"}],
+            },
+            {"instruction_type": "goto_table", "table_id": new_table_id},
+        ]
+        new_int_flow_tbl_0_tcp["flow"]["instructions"] = instructions
+
+        # Prepare UDP Flow for Table 0. Everything the same as TCP except the nw_proto
+        new_int_flow_tbl_0_udp = copy.deepcopy(new_int_flow_tbl_0_tcp)
+        new_int_flow_tbl_0_udp["flow"]["match"]["nw_proto"] = settings.UDP
+
+        # Prepare Flows for Table X - No TCP or UDP specifics
+        new_int_flow_tbl_x["flow"]["table_id"] = new_table_id
+
+        # if intra-switch EVC, then output port should be the dst UNI's source port
+        if utils.is_intra_switch_evc(evc):
+            dst_uni = evc["uni_z" if uni_src_key == "uni_a" else "uni_a"]
+            proxy_port = dst_uni["proxy_port"]
+            for instruction in new_int_flow_tbl_x["flow"]["instructions"]:
+                if instruction["instruction_type"] == "apply_actions":
+                    for action in instruction["actions"]:
+                        if action["action_type"] == "output":
+                            # Since this is the INT Source, we use source
+                            # to avoid worrying about single or multi
+                            # home physical loops.
+                            # The choice for destination is at the INT Sink.
+                            action["port"] = proxy_port.source.port_number
+
+                    # remove set_vlan action if it exists, this is for
+                    # avoding a redundant set_vlan since it'll be set in the egress sink
+                    instruction["actions"] = utils.modify_actions(
+                        instruction["actions"], ["set_vlan"], remove=True
+                    )
+
+        instructions = utils.add_to_apply_actions(
+            new_int_flow_tbl_x["flow"]["instructions"],
+            new_instruction={"action_type": "add_int_metadata"},
+            position=0,
+        )
+
+        new_int_flow_tbl_x["flow"]["instructions"] = instructions
+
+        new_flows.append(new_int_flow_tbl_0_tcp)
+        new_flows.append(new_int_flow_tbl_0_udp)
+        new_flows.append(new_int_flow_tbl_x)
+
+        return new_flows
+
+    def _build_int_hop_flows(
+        self,
+        evc: dict,
+        stored_flows: dict[int, list[dict]],
+    ) -> list[dict]:
+        """Build INT hop flows.
+
+        At the INT hops, one flow adds two more: one for UDP on table 0,
+        one for TCP on table 0. On table 0, we add 'add_int_metadata'
+        before other actions.
+        """
+
+        new_flows = []
+        excluded_dpids = set([evc["uni_a"]["switch"], evc["uni_z"]["switch"]])
+
+        for flow in stored_flows[
+            utils.get_cookie(evc["id"], settings.MEF_COOKIE_PREFIX)
+        ]:
+            if flow["switch"] in excluded_dpids:
+                continue
+            if "match" not in flow["flow"] or "in_port" not in flow["flow"]["match"]:
+                continue
+
+            new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
+            utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
+            utils.set_new_cookie(new_int_flow_tbl_0_tcp)
+            utils.set_owner(new_int_flow_tbl_0_tcp)
+
+            # Prepare TCP Flow
             new_int_flow_tbl_0_tcp["flow"]["match"]["dl_type"] = settings.IPv4
             new_int_flow_tbl_0_tcp["flow"]["match"]["nw_proto"] = settings.TCP
             utils.set_priority(new_int_flow_tbl_0_tcp)
 
-            # Add telemetry, keep set_queue, output to the proxy port.
-            output_port_no = proxy_port.source.port_number
             for instruction in new_int_flow_tbl_0_tcp["flow"]["instructions"]:
                 if instruction["instruction_type"] == "apply_actions":
-                    # Keep set_queue
-                    actions = utils.modify_actions(
-                        instruction["actions"],
-                        ["pop_vlan", "push_vlan", "set_vlan", "output"],
-                        remove=True,
+                    instruction["actions"].insert(
+                        0, {"action_type": "add_int_metadata"}
                     )
-                    actions.insert(0, {"action_type": "add_int_metadata"})
-                    actions.append({"action_type": "output", "port": output_port_no})
-                    instruction["actions"] = actions
 
-            # Prepare UDP Flow for Table 0
+            # Prepare UDP Flow
             new_int_flow_tbl_0_udp = copy.deepcopy(new_int_flow_tbl_0_tcp)
             new_int_flow_tbl_0_udp["flow"]["match"]["nw_proto"] = settings.UDP
 
-            new_flows.append(copy.deepcopy(new_int_flow_tbl_0_tcp))
-            new_flows.append(copy.deepcopy(new_int_flow_tbl_0_udp))
+            new_flows.append(new_int_flow_tbl_0_tcp)
+            new_flows.append(new_int_flow_tbl_0_udp)
 
-        # Prepare Flows for Table 0 AFTER proxy. No difference between TCP or UDP
-        in_port_no = proxy_port.destination.port_number
+        return new_flows
 
-        new_int_flow_tbl_0_pos["flow"]["match"]["in_port"] = in_port_no
-        utils.set_priority(new_int_flow_tbl_0_tcp)
+    def _build_int_sink_flows(
+        self,
+        uni_dst_key: Literal["uni_a", "uni_z"],
+        evc: dict,
+        stored_flows: dict[int, list[dict]],
+    ) -> list[dict]:
+        """
+        Build INT sink flows.
 
-        instructions = [
-            {
-                "instruction_type": "apply_actions",
-                "actions": [{"action_type": "send_report"}],
-            },
-            {"instruction_type": "goto_table", "table_id": settings.INT_TABLE},
-        ]
-        new_int_flow_tbl_0_pos["flow"]["instructions"] = instructions
+        At the INT sink, one flow becomes many:
+        1. Before the proxy, we do add_int_metadata as an INT hop.
+        We need to keep the set_queue
+        2. After the proxy, we do send_report and pop_int and output
+        We only use table 0 for #1.
+        We use table X (2 or 3) for #2. for pop_int and output
+        """
+        new_flows = []
+        dst_uni = evc[uni_dst_key]
+        proxy_port = dst_uni["proxy_port"]
+        dpid = dst_uni["switch"]
 
-        # Prepare Flows for Table 2 POS proxy
-        new_int_flow_tbl_2_pos["flow"]["match"]["in_port"] = in_port_no
-        new_int_flow_tbl_2_pos["flow"]["table_id"] = settings.INT_TABLE
-        utils.set_table_group(new_int_flow_tbl_2_pos)
+        for flow in stored_flows[
+            utils.get_cookie(evc["id"], settings.MEF_COOKIE_PREFIX)
+        ]:
+            # Only consider this sink's dpid flows
+            if flow["switch"] != dpid:
+                continue
+            # Only consider flows coming from NNI interfaces
+            if flow["flow"]["match"]["in_port"] == dst_uni["port_number"]:
+                continue
 
-        for instruction in new_int_flow_tbl_2_pos["flow"]["instructions"]:
-            if instruction["instruction_type"] == "apply_actions":
-                instruction["actions"].insert(0, {"action_type": "pop_int"})
+            new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
 
-        new_flows.append(copy.deepcopy(new_int_flow_tbl_0_pos))
-        new_flows.append(copy.deepcopy(new_int_flow_tbl_2_pos))
+            if not new_int_flow_tbl_0_tcp:
+                raise FlowsNotFound(evc["id"])
 
-    return new_flows
+            utils.set_new_cookie(new_int_flow_tbl_0_tcp)
+            utils.set_owner(new_int_flow_tbl_0_tcp)
+            utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
+
+            # Save for pos-proxy flows
+            new_int_flow_tbl_0_pos = copy.deepcopy(new_int_flow_tbl_0_tcp)
+            new_int_flow_tbl_x_pos = copy.deepcopy(new_int_flow_tbl_0_tcp)
+
+            # Prepare TCP Flow for Table 0 PRE proxy
+            if not utils.is_intra_switch_evc(evc):
+                new_int_flow_tbl_0_tcp["flow"]["match"]["dl_type"] = settings.IPv4
+                new_int_flow_tbl_0_tcp["flow"]["match"]["nw_proto"] = settings.TCP
+                utils.set_priority(new_int_flow_tbl_0_tcp)
+
+                # Add telemetry, keep set_queue, output to the proxy port.
+                output_port_no = proxy_port.source.port_number
+                for instruction in new_int_flow_tbl_0_tcp["flow"]["instructions"]:
+                    if instruction["instruction_type"] == "apply_actions":
+                        # Keep set_queue
+                        actions = utils.modify_actions(
+                            instruction["actions"],
+                            ["pop_vlan", "push_vlan", "set_vlan", "output"],
+                            remove=True,
+                        )
+                        actions.insert(0, {"action_type": "add_int_metadata"})
+                        actions.append(
+                            {"action_type": "output", "port": output_port_no}
+                        )
+                        instruction["actions"] = actions
+
+                # Prepare UDP Flow for Table 0
+                new_int_flow_tbl_0_udp = copy.deepcopy(new_int_flow_tbl_0_tcp)
+                new_int_flow_tbl_0_udp["flow"]["match"]["nw_proto"] = settings.UDP
+
+                new_flows.append(copy.deepcopy(new_int_flow_tbl_0_tcp))
+                new_flows.append(copy.deepcopy(new_int_flow_tbl_0_udp))
+
+            # Prepare Flows for Table 0 AFTER proxy. No difference between TCP or UDP
+            in_port_no = proxy_port.destination.port_number
+
+            new_int_flow_tbl_0_pos["flow"]["match"]["in_port"] = in_port_no
+            utils.set_priority(new_int_flow_tbl_0_tcp)
+
+            table_group = self.table_group
+            new_table_id = table_group[new_int_flow_tbl_x_pos["flow"]["table_group"]]
+            instructions = [
+                {
+                    "instruction_type": "apply_actions",
+                    "actions": [{"action_type": "send_report"}],
+                },
+                {
+                    "instruction_type": "goto_table",
+                    "table_id": new_table_id,
+                },
+            ]
+            new_int_flow_tbl_0_pos["flow"]["instructions"] = instructions
+
+            # Prepare Flows for Table X POS proxy
+            new_int_flow_tbl_x_pos["flow"]["match"]["in_port"] = in_port_no
+            new_int_flow_tbl_x_pos["flow"]["table_id"] = new_table_id
+
+            for instruction in new_int_flow_tbl_x_pos["flow"]["instructions"]:
+                if instruction["instruction_type"] == "apply_actions":
+                    instruction["actions"].insert(0, {"action_type": "pop_int"})
+
+            new_flows.append(copy.deepcopy(new_int_flow_tbl_0_pos))
+            new_flows.append(copy.deepcopy(new_int_flow_tbl_x_pos))
+
+        return new_flows

--- a/managers/int.py
+++ b/managers/int.py
@@ -11,7 +11,7 @@ from napps.kytos.telemetry_int import utils
 from napps.kytos.telemetry_int import settings
 from kytos.core import log
 import napps.kytos.telemetry_int.kytos_api_helper as api
-from napps.kytos.telemetry_int.managers import flow_builder
+from napps.kytos.telemetry_int.managers.flow_builder import FlowBuilder
 from kytos.core.common import EntityStatus
 
 from napps.kytos.telemetry_int.exceptions import (
@@ -30,6 +30,7 @@ class INTManager:
     def __init__(self, controller: Controller) -> None:
         """INTManager."""
         self.controller = controller
+        self.flow_builder = FlowBuilder()
 
     async def disable_int(self, evcs: dict[str, dict], force=False) -> None:
         """Disable INT on EVCs.
@@ -79,7 +80,7 @@ class INTManager:
 
         log.info(f"Enabling INT on EVC ids: {list(evcs.keys())}, force: {force}")
 
-        stored_flows = flow_builder.build_int_flows(
+        stored_flows = self.flow_builder.build_int_flows(
             evcs,
             await utils.get_found_stored_flows(
                 [

--- a/settings.py
+++ b/settings.py
@@ -5,10 +5,11 @@ mef_eline_api = f"{KYTOS_API}/kytos/mef_eline/v2"
 flow_manager_api = f"{KYTOS_API}/kytos/flow_manager/v2"
 INT_COOKIE_PREFIX = 0xA8
 MEF_COOKIE_PREFIX = 0xAA
-INT_TABLE = 2
 IPv4 = 2048
 TCP = 6
 UDP = 17
+
+TABLE_GROUP_ALLOWED = {"evpl", "epl"}
 
 # BATCH_INTERVAL: time interval between batch requests that will be sent to
 # flow_manager (in seconds) - zero enable sending all the requests in a row

--- a/tests/unit/test_flow_builder_inter_evc.py
+++ b/tests/unit/test_flow_builder_inter_evc.py
@@ -1,7 +1,7 @@
 """Test flow_builder."""
 
 from unittest.mock import MagicMock
-from napps.kytos.telemetry_int.managers import flow_builder as fb
+from napps.kytos.telemetry_int.managers.flow_builder import FlowBuilder
 from napps.kytos.telemetry_int.managers.int import INTManager
 from napps.kytos.telemetry_int.utils import ProxyPort, get_cookie
 from napps.kytos.telemetry_int import settings
@@ -95,7 +95,7 @@ def test_build_int_flows_inter_evpl(
     stored_flows = _map_stored_flows_by_cookies(inter_evc_evpl_flows_data)
 
     cookie = get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
-    flows = fb.build_int_flows(evcs_data, stored_flows)[cookie]
+    flows = FlowBuilder().build_int_flows(evcs_data, stored_flows)[cookie]
 
     n_expected_source_flows, n_expected_hop_flows, n_expected_sink_flows = 3, 2, 4
     assert (
@@ -153,7 +153,7 @@ def test_build_int_flows_inter_evpl(
                 "cookie": int(0xA816A76AE61B2F46),
                 "match": {"in_port": 1, "dl_vlan": 101},
                 "table_id": 2,
-                "table_group": "base",
+                "table_group": "evpl",
                 "priority": 20000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -223,7 +223,7 @@ def test_build_int_flows_inter_evpl(
                 "cookie": int(0xA816A76AE61B2F46),
                 "match": {"in_port": 1, "dl_vlan": 102},
                 "table_id": 2,
-                "table_group": "base",
+                "table_group": "evpl",
                 "priority": 20000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -402,7 +402,7 @@ def test_build_int_flows_inter_evpl(
                 "cookie": int(0xA816A76AE61B2F46),
                 "match": {"in_port": 6, "dl_vlan": 1},
                 "table_id": 2,
-                "table_group": "base",
+                "table_group": "evpl",
                 "priority": 20000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -488,7 +488,7 @@ def test_build_int_flows_inter_evpl(
                 "cookie": int(0xA816A76AE61B2F46),
                 "match": {"in_port": 6, "dl_vlan": 1},
                 "table_id": 2,
-                "table_group": "base",
+                "table_group": "evpl",
                 "priority": 20000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,

--- a/tests/unit/test_flow_builder_intra_evc.py
+++ b/tests/unit/test_flow_builder_intra_evc.py
@@ -10,6 +10,11 @@ from kytos.lib.helpers import get_controller_mock, get_switch_mock, get_interfac
 from kytos.core.common import EntityStatus
 
 
+def test_flow_builder_default_table_groups() -> None:
+    """test flow builder default table groups."""
+    assert FlowBuilder().table_group == {"evpl": 2, "epl": 3}
+
+
 def test_build_int_flows_intra_evpl(
     evcs_data, intra_evc_evpl_flows_data, monkeypatch
 ) -> None:

--- a/tests/unit/test_flow_builder_intra_evc.py
+++ b/tests/unit/test_flow_builder_intra_evc.py
@@ -1,7 +1,7 @@
 """Test flow_builder."""
 
 from unittest.mock import MagicMock
-from napps.kytos.telemetry_int.managers import flow_builder as fb
+from napps.kytos.telemetry_int.managers.flow_builder import FlowBuilder
 from napps.kytos.telemetry_int.managers.int import INTManager
 from napps.kytos.telemetry_int.utils import ProxyPort, get_cookie
 from napps.kytos.telemetry_int import settings
@@ -93,7 +93,7 @@ def test_build_int_flows_intra_evpl(
     stored_flows = _map_stored_flows_by_cookies(intra_evc_evpl_flows_data)
 
     cookie = get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
-    flows = fb.build_int_flows(evcs_data, stored_flows)[cookie]
+    flows = FlowBuilder().build_int_flows(evcs_data, stored_flows)[cookie]
 
     n_expected_source_flows, n_expected_sink_flows = 3, 2
     assert len(flows) == (n_expected_source_flows + n_expected_sink_flows) * 2
@@ -148,7 +148,7 @@ def test_build_int_flows_intra_evpl(
                 "cookie": int(0xA83766C105686749),
                 "match": {"in_port": 1, "dl_vlan": 200},
                 "table_id": 2,
-                "table_group": "base",
+                "table_group": "evpl",
                 "priority": 20000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -215,7 +215,7 @@ def test_build_int_flows_intra_evpl(
                 "cookie": int(0xA83766C105686749),
                 "match": {"in_port": 2, "dl_vlan": 200},
                 "table_id": 2,
-                "table_group": "base",
+                "table_group": "evpl",
                 "priority": 20000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -258,7 +258,7 @@ def test_build_int_flows_intra_evpl(
                 "cookie": int(0xA83766C105686749),
                 "match": {"in_port": 11, "dl_vlan": 200},
                 "table_id": 2,
-                "table_group": "base",
+                "table_group": "evpl",
                 "priority": 20000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -301,7 +301,7 @@ def test_build_int_flows_intra_evpl(
                 "cookie": int(0xA83766C105686749),
                 "match": {"in_port": 21, "dl_vlan": 200},
                 "table_id": 2,
-                "table_group": "base",
+                "table_group": "evpl",
                 "priority": 20000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -413,7 +413,7 @@ def test_build_int_flows_intra_epl(
     stored_flows = _map_stored_flows_by_cookies(intra_evc_epl_flows_data)
 
     cookie = get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
-    flows = fb.build_int_flows(evcs_data, stored_flows)[cookie]
+    flows = FlowBuilder().build_int_flows(evcs_data, stored_flows)[cookie]
 
     n_expected_source_flows, n_expected_sink_flows = 3, 2
     assert len(flows) == (n_expected_source_flows + n_expected_sink_flows) * 2
@@ -434,7 +434,7 @@ def test_build_int_flows_intra_epl(
                         "instruction_type": "apply_actions",
                         "actions": [{"action_type": "push_int"}],
                     },
-                    {"instruction_type": "goto_table", "table_id": 2},
+                    {"instruction_type": "goto_table", "table_id": 3},
                 ],
             }
         },
@@ -457,7 +457,7 @@ def test_build_int_flows_intra_epl(
                         "instruction_type": "apply_actions",
                         "actions": [{"action_type": "push_int"}],
                     },
-                    {"instruction_type": "goto_table", "table_id": 2},
+                    {"instruction_type": "goto_table", "table_id": 3},
                 ],
             }
         },
@@ -466,8 +466,8 @@ def test_build_int_flows_intra_epl(
                 "owner": "telemetry_int",
                 "cookie": int(0xA83766C105686749),
                 "match": {"in_port": 1},
-                "table_id": 2,
-                "table_group": "base",
+                "table_id": 3,
+                "table_group": "epl",
                 "priority": 10000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -500,7 +500,7 @@ def test_build_int_flows_intra_epl(
                         "instruction_type": "apply_actions",
                         "actions": [{"action_type": "push_int"}],
                     },
-                    {"instruction_type": "goto_table", "table_id": 2},
+                    {"instruction_type": "goto_table", "table_id": 3},
                 ],
             }
         },
@@ -523,7 +523,7 @@ def test_build_int_flows_intra_epl(
                         "instruction_type": "apply_actions",
                         "actions": [{"action_type": "push_int"}],
                     },
-                    {"instruction_type": "goto_table", "table_id": 2},
+                    {"instruction_type": "goto_table", "table_id": 3},
                 ],
             }
         },
@@ -532,8 +532,8 @@ def test_build_int_flows_intra_epl(
                 "owner": "telemetry_int",
                 "cookie": int(0xA83766C105686749),
                 "match": {"in_port": 2},
-                "table_id": 2,
-                "table_group": "base",
+                "table_id": 3,
+                "table_group": "epl",
                 "priority": 10000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -566,7 +566,7 @@ def test_build_int_flows_intra_epl(
                         "instruction_type": "apply_actions",
                         "actions": [{"action_type": "send_report"}],
                     },
-                    {"instruction_type": "goto_table", "table_id": 2},
+                    {"instruction_type": "goto_table", "table_id": 3},
                 ],
             },
         },
@@ -575,8 +575,8 @@ def test_build_int_flows_intra_epl(
                 "owner": "telemetry_int",
                 "cookie": int(0xA83766C105686749),
                 "match": {"in_port": 11},
-                "table_id": 2,
-                "table_group": "base",
+                "table_id": 3,
+                "table_group": "epl",
                 "priority": 10000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,
@@ -608,7 +608,7 @@ def test_build_int_flows_intra_epl(
                         "instruction_type": "apply_actions",
                         "actions": [{"action_type": "send_report"}],
                     },
-                    {"instruction_type": "goto_table", "table_id": 2},
+                    {"instruction_type": "goto_table", "table_id": 3},
                 ],
             },
         },
@@ -617,8 +617,8 @@ def test_build_int_flows_intra_epl(
                 "owner": "telemetry_int",
                 "cookie": int(0xA83766C105686749),
                 "match": {"in_port": 21},
-                "table_id": 2,
-                "table_group": "base",
+                "table_id": 3,
+                "table_group": "epl",
                 "priority": 10000,
                 "idle_timeout": 0,
                 "hard_timeout": 0,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -97,6 +97,7 @@ class TestMain:
 
     async def test_on_table_enabled(self) -> None:
         """Test on_table_enabled."""
+        assert self.napp.int_manager.flow_builder.table_group == {"evpl": 2, "epl": 3}
         await self.napp.on_table_enabled(
             KytosEvent(content={"telemetry_int": {"evpl": 22, "epl": 33}})
         )
@@ -105,11 +106,13 @@ class TestMain:
 
     async def test_on_table_enabled_error(self, monkeypatch) -> None:
         """Test on_table_enabled error case."""
+        assert self.napp.int_manager.flow_builder.table_group == {"evpl": 2, "epl": 3}
         log_mock = MagicMock()
         monkeypatch.setattr("napps.kytos.telemetry_int.main.log", log_mock)
         await self.napp.on_table_enabled(
             KytosEvent(content={"telemetry_int": {"invalid": 1}})
         )
+        assert self.napp.int_manager.flow_builder.table_group == {"evpl": 2, "epl": 3}
         assert log_mock.error.call_count == 1
         assert not self.napp.controller.buffers.app.aput.call_count
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -95,6 +95,24 @@ class TestMain:
         assert len(data) == 1
         assert evc_id in data
 
+    async def test_on_table_enabled(self) -> None:
+        """Test on_table_enabled."""
+        await self.napp.on_table_enabled(
+            KytosEvent(content={"telemetry_int": {"evpl": 22, "epl": 33}})
+        )
+        assert self.napp.int_manager.flow_builder.table_group == {"evpl": 22, "epl": 33}
+        assert self.napp.controller.buffers.app.aput.call_count == 1
+
+    async def test_on_table_enabled_error(self, monkeypatch) -> None:
+        """Test on_table_enabled error case."""
+        log_mock = MagicMock()
+        monkeypatch.setattr("napps.kytos.telemetry_int.main.log", log_mock)
+        await self.napp.on_table_enabled(
+            KytosEvent(content={"telemetry_int": {"invalid": 1}})
+        )
+        assert log_mock.error.call_count == 1
+        assert not self.napp.controller.buffers.app.aput.call_count
+
     async def test_on_flow_mod_error(self, monkeypatch) -> None:
         """Test on_flow_mod_error."""
         api_mock, flow = AsyncMock(), MagicMock()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -180,21 +180,6 @@ def test_set_owner() -> None:
     assert flow["flow"]["owner"] == "telemetry_int"
 
 
-def test_set_table_group() -> None:
-    """Test set_table_group."""
-    flow = {
-        "flow": {
-            "priority": 100,
-            "match": {"in_port": 100},
-            "actions": [{"action_type": "output", "port": 1}],
-        }
-    }
-    utils.set_table_group(flow)
-    assert flow["flow"]["table_group"] == "base"
-    utils.set_table_group(flow, "another")
-    assert flow["flow"]["table_group"] == "another"
-
-
 @pytest.mark.parametrize(
     "actions,actions_to_change,remove,expected_actions",
     [

--- a/utils.py
+++ b/utils.py
@@ -153,12 +153,6 @@ def set_owner(flow: dict) -> dict:
     return flow
 
 
-def set_table_group(flow: dict, table_group="base") -> dict:
-    """Set flow owner."""
-    flow["flow"]["table_group"] = table_group
-    return flow
-
-
 def get_new_cookie(cookie: int, cookie_prefix=settings.INT_COOKIE_PREFIX) -> int:
     """Convert from mef-eline cookie by replacing the most significant byte."""
     return (cookie & 0xFFFFFFFFFFFFFF) + (cookie_prefix << 56)


### PR DESCRIPTION
Closes #13 
Closes #43 

This PR is on top of PR #39 

This PR is also related to https://github.com/kytos-ng/of_multi_table/pull/21

### Summary

- Integration with `of_multi_table` supporting `evpl` and `epl` table groups on table 2 and 3 by default. Subcribed to `kytos/of_multi_table.enable_table`
- Refactored flow_builder module aggregating it into a class and parametrizing the table groups accordingly based on existing `evpl` and `evpl` flows (this resulted in larger diffs, but it's mostly just code moving around)
- This NApp hasn't been released yet, so no need to update the changelog

### Local Tests

- With `of_multi_table` also enabled and running with default settings, on NoviFlow lab I created an intra-evpl, intra-epl, inter-epl and inter-epl, I observed that all existing `"evpl"` table groups were installed on table 2 and `"epl"` on table 3 as expected. 

Here's an output of two examples (I didn't post them all to avoid cluttering too much), intra epl and inter evpl respectively:

```
2023-10-11 16:55:46,683 - INFO [kytos.napps.kytos/mef_eline] [evc.py:826:deploy_to_path] (AnyIO worker thread) EVC(8f3980d93fbd40, intra_epl) was deployed.
2023-10-11 16:55:46,685 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46818 - "POST /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 201
2023-10-11 16:56:47,030 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:55696 - "GET /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 200
2023-10-11 16:58:17,499 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:54040 - "GET /api/kytos/mef_eline/v2/evc/8f3980d93fbd40 HTTP/1.1" 200
2023-10-11 16:58:17,501 - INFO [kytos.napps.kytos/telemetry_int] [int.py:81:enable_int] (MainThread) Enabling INT on EVC ids: ['8f3980d93fbd40'], force: False
2023-10-11 16:58:17,510 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:54050 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HT
TP/1.1" 200
2023-10-11 16:58:17,518 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_16) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command
: add, force: True,  flows[0, 10]: [{'owner': 'telemetry_int', 'cookie': 12145989945604947264, 'match': {'in_port': 15, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'e
pl', 'priority': 10100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'got
o_table', 'table_id': 3}]}, {'owner': 'telemetry_int', 'cookie': 12145989945604947264, 'match': {'in_port': 15, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'epl', 'p
riority': 10100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table
', 'table_id': 3}]}, {'owner': 'telemetry_int', 'cookie': 12145989945604947264, 'match': {'in_port': 15}, 'table_id': 3, 'table_group': 'epl', 'priority': 10000, 'idle_timeout': 0, 'har
d_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 19}]}]}, {'owner': 'telemetry_in
t', 'cookie': 12145989945604947264, 'match': {'in_port': 16, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'epl', 'priority': 10100, 'idle_timeout': 0, 'hard_timeout': 
0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 3}]}, {'owner': 'telemetry_int', 'coo
kie': 12145989945604947264, 'match': {'in_port': 16, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'epl', 'priority': 10100, 'idle_timeout': 0, 'hard_timeout': 0, 'ins
tructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 3}]}, {'owner': 'telemetry_int', 'cookie': 1
2145989945604947264, 'match': {'in_port': 16}, 'table_id': 3, 'table_group': 'epl', 'priority': 10000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply
_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_int', 'cookie': 12145989945604947264, 'match': {'in_port': 20
}, 'table_id': 0, 'table_group': 'epl', 'priority': 10000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send
_report'}]}, {'instruction_type': 'goto_table', 'table_id': 3}]}, {'owner': 'telemetry_int', 'cookie': 12145989945604947264, 'match': {'in_port': 20}, 'table_id': 3, 'table_group': 'epl
', 'priority': 10000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'output', 'por
t': 16}]}]}, {'owner': 'telemetry_int', 'cookie': 12145989945604947264, 'match': {'in_port': 18}, 'table_id': 0, 'table_group': 'epl', 'priority': 10000, 'idle_timeout': 0, 'hard_timeou
t': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 3}]}, {'owner': 'telemetry_int
', 'cookie': 12145989945604947264, 'match': {'in_port': 18}, 'table_id': 3, 'table_group': 'epl', 'priority': 10000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction
_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'output', 'port': 15}]}]}]
2023-10-11 16:58:17,543 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:54052 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-10-11 16:58:17,545 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:54036 - "POST /api/kytos/telemetry_int/v1/evc/enable HTTP/1.1" 201
kytos $>                                                                                                                                                                                 
```

```
2023-10-11 16:48:02,588 - WARNING [kytos.napps.kytos/mef_eline] [evc.py:880:setup_failover_path] (thread_pool_app_14) Failover path for EVC(1fe56e255dac47, inter_evpl) was not deployed:
 No available path was found
2023-10-11 16:48:12,079 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:56122 - "GET /api/kytos/mef_eline/v2/evc/1fe56e255dac47 HTTP/1.1" 200
2023-10-11 16:48:12,080 - INFO [kytos.napps.kytos/telemetry_int] [int.py:81:enable_int] (MainThread) Enabling INT on EVC ids: ['1fe56e255dac47'], force: False
2023-10-11 16:48:12,089 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:56126 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HT
TP/1.1" 200
2023-10-11 16:48:12,098 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_3) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command:
 add, force: True,  flows[0, 7]: [{'owner': 'telemetry_int', 'cookie': 12114653783885982791, 'match': {'in_port': 15, 'dl_vlan': 100, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'ta
ble_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruct
ion_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12114653783885982791, 'match': {'in_port': 15, 'dl_vlan': 100, 'dl_type': 2048, 'nw_proto': 17}, 'table_i
d': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, 
{'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12114653783885982791, 'match': {'in_port': 15, 'dl_vlan': 100}, 'table_id': 2, 'table_group': '
evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': '
set_vlan', 'vlan_id': 100}, {'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int
', 'cookie': 12114653783885982791, 'match': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'h
ard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_
int', 'cookie': 12114653783885982791, 'match': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0
, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'teleme
try_int', 'cookie': 12114653783885982791, 'match': {'in_port': 18, 'dl_vlan': 1}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instruc
tions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12
114653783885982791, 'match': {'in_port': 18, 'dl_vlan': 1}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction
_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}]
2023-10-11 16:48:12,104 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_6) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command:
 add, force: True,  flows[0, 7]: [{'owner': 'telemetry_int', 'cookie': 12114653783885982791, 'match': {'in_port': 22, 'dl_vlan': 100, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'ta
ble_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruct
ion_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12114653783885982791, 'match': {'in_port': 22, 'dl_vlan': 100, 'dl_type': 2048, 'nw_proto': 17}, 'table_i
d': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, 
{'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12114653783885982791, 'match': {'in_port': 22, 'dl_vlan': 100}, 'table_id': 2, 'table_group': '
evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': '
set_vlan', 'vlan_id': 100}, {'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int
', 'cookie': 12114653783885982791, 'match': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'h
ard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'owner': 'telemetry_
int', 'cookie': 12114653783885982791, 'match': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0
, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'owner': 'teleme
try_int', 'cookie': 12114653783885982791, 'match': {'in_port': 26, 'dl_vlan': 1}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instruc
tions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12
114653783885982791, 'match': {'in_port': 26, 'dl_vlan': 1}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction
_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 22}]}]}]
2023-10-11 16:48:12,142 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:56132 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-10-11 16:48:12,143 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:56108 - "POST /api/kytos/telemetry_int/v1/evc/enable HTTP/1.1" 201
kytos $>                                                                                                                                                                                 

```

- I've also confirmed the table stats increasing with data plane traffic:

```
❯ http localhost:8181/api/amlight/kytos_stats/v1/table/stats
HTTP/1.1 200 OK
content-length: 700
content-type: application/json
date: Wed, 11 Oct 2023 20:05:40 GMT
server: uvicorn

{
    "00:00:00:00:00:00:00:01": {
        "0": {
            "active_count": 17,
            "lookup_count": 802851678,
            "matched_count": 802753828,
            "table_id": 0
        },
        "1": {
            "active_count": 0,
            "lookup_count": 0,
            "matched_count": 0,
            "table_id": 1
        },
        "2": {
            "active_count": 2,
            "lookup_count": 628012374,
            "matched_count": 628011695,
            "table_id": 2
        },
        "3": {
            "active_count": 4,
            "lookup_count": 5146022,
            "matched_count": 5146022,
            "table_id": 3
        }
    },
    "00:00:00:00:00:00:00:06": {
        "0": {
            "active_count": 9,
            "lookup_count": 738211284,
            "matched_count": 374128980,
            "table_id": 0
        },
        "1": {
            "active_count": 0,
            "lookup_count": 0,
            "matched_count": 0,
            "table_id": 1
        },
        "2": {
            "active_count": 2,
            "lookup_count": 91668004,
            "matched_count": 91668004,
            "table_id": 2
        },
        "3": {
            "active_count": 0,
            "lookup_count": 0,
            "matched_count": 0,
            "table_id": 3
        }
    }
}
```

### End-to-End Tests

N/A yet
