### PR TITLE
feat: handle proxy port link, flows network convergence

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -38,6 +38,10 @@ class ProxyPortNotFound(ProxyPortError):
     """ProxyPortNotFound."""
 
 
+class ProxyPortDestNotFound(ProxyPortError):
+    """ProxyPorDesttNotFound."""
+
+
 class ProxyPortStatusNotUP(ProxyPortError):
     """ProxyPortStatusNotUP."""
 

--- a/main.py
+++ b/main.py
@@ -206,7 +206,8 @@ class Main(KytosNApp):
     async def on_mef_eline_loaded(self, _event: KytosEvent) -> None:
         """Handle kytos/mef_eline.loaded.
 
-        In the future api.get_evcs request will get replaced via a new event
+        In the future api.get_evcs request will get replaced via a new event TODO
+        https://github.com/kytos-ng/telemetry_int/issues/66
         """
         evcs = await api.get_evcs(archived=False)
         self.int_manager.load_uni_src_proxy_ports(evcs)

--- a/managers/int.py
+++ b/managers/int.py
@@ -174,7 +174,10 @@ class INTManager:
                 log.exception(exc)
                 return
 
-            log.info(f"Handling link_up {link}, deploying EVC ids: {list(to_install)}")
+            log.info(
+                f"Handling link_up {link}, deploying INT flows, "
+                f"EVC ids: {list(to_install)}"
+            )
             metadata = {
                 "telemetry": {
                     "enabled": True,

--- a/managers/int.py
+++ b/managers/int.py
@@ -125,11 +125,12 @@ class INTManager:
         if not pp or not pp.evc_ids:
             return
 
-        # This sleep is to await for at least one of_lldp polling interval cycle
-        # just so it always has enough time to detect the loop.
-        # In the worst case, consistency check will also try to activate later on
-        # TODO this value will be stored and subscribed from of_lldp in a next PR
-        await asyncio.sleep(3 * 1.5)
+        # This sleep is to wait for at least a few seconds to ensure that the other
+        # proxy port would also have been considered up since the request
+        # on topology setting metadata might end up delaying, check out issue
+        # https://github.com/kytos-ng/of_lldp/issues/100
+        # TODO this will be optimized later on before releasing this NApp
+        await asyncio.sleep(5)
 
         async with self._topo_link_lock:
             if link.status != EntityStatus.UP or link.status_reason:

--- a/managers/int.py
+++ b/managers/int.py
@@ -78,7 +78,7 @@ class INTManager:
 
     async def handle_pp_link_down(self, link: Link) -> None:
         """Handle proxy_port link_down."""
-        if not settings.FALLBACK_MEF_LOOP_STOPPED:
+        if not settings.FALLBACK_TO_MEF_LOOP_DOWN:
             return
         pp = self.srcs_pp.get(link.endpoint_a.id)
         if not pp:
@@ -117,7 +117,7 @@ class INTManager:
 
     async def handle_pp_link_up(self, link: Link) -> None:
         """Handle proxy_port link_up."""
-        if not settings.FALLBACK_MEF_LOOP_STOPPED:
+        if not settings.FALLBACK_TO_MEF_LOOP_DOWN:
             return
         pp = self.srcs_pp.get(link.endpoint_a.id)
         if not pp:

--- a/proxy_port.py
+++ b/proxy_port.py
@@ -12,12 +12,14 @@ class ProxyPort:
 
     source interface is where the loop starts
     destination interface is where the loop ends
+    evc_ids are which evc ids this proxy port is being used by
 
     """
 
     def __init__(self, controller: Controller, source: Interface):
         self.controller = controller
         self.source = source
+        self.evc_ids: set[str] = set()
 
     @property
     def destination(self) -> Optional[Interface]:
@@ -48,3 +50,7 @@ class ProxyPort:
         ):
             return EntityStatus.UP
         return EntityStatus.DOWN
+
+    def __repr__(self) -> str:
+        """Repr method."""
+        return f"ProxyPort({self.source}, {self.destination}, {self.status})"

--- a/settings.py
+++ b/settings.py
@@ -19,3 +19,7 @@ BATCH_INTERVAL = 0.2
 # number of FlowMod requests. Use 0 (zero) to disable BATCH mode, i.e. sends
 # everything at a glance
 BATCH_SIZE = 200
+
+# Fallback to mef_eline by removing INT flows if an external loop goes down. If
+# the loop goes UP again and the EVC is active, it'll install INT flows
+FALLBACK_TO_MEF_LOOP_DOWN = True

--- a/tests/unit/test_flow_builder_inter_evc.py
+++ b/tests/unit/test_flow_builder_inter_evc.py
@@ -3,16 +3,15 @@
 from unittest.mock import MagicMock
 from napps.kytos.telemetry_int.managers.flow_builder import FlowBuilder
 from napps.kytos.telemetry_int.managers.int import INTManager
-from napps.kytos.telemetry_int.utils import ProxyPort, get_cookie
+from napps.kytos.telemetry_int.utils import get_cookie
+from napps.kytos.telemetry_int.proxy_port import ProxyPort
 from napps.kytos.telemetry_int import settings
 from napps.kytos.telemetry_int.kytos_api_helper import _map_stored_flows_by_cookies
 from kytos.lib.helpers import get_controller_mock, get_switch_mock, get_interface_mock
 from kytos.core.common import EntityStatus
 
 
-def test_build_int_flows_inter_evpl(
-    evcs_data, inter_evc_evpl_flows_data, monkeypatch
-) -> None:
+def test_build_int_flows_inter_evpl(evcs_data, inter_evc_evpl_flows_data) -> None:
     """Test build INT flows inter EVPL.
 
                +----+                                              +----+
@@ -29,10 +28,7 @@ def test_build_int_flows_inter_evpl(
     controller = get_controller_mock()
     int_manager = INTManager(controller)
     get_proxy_port_or_raise = MagicMock()
-    monkeypatch.setattr(
-        "napps.kytos.telemetry_int.utils.get_proxy_port_or_raise",
-        get_proxy_port_or_raise,
-    )
+    int_manager.get_proxy_port_or_raise = get_proxy_port_or_raise
 
     evc_id = "16a76ae61b2f46"
     dpid_a = "00:00:00:00:00:00:00:01"

--- a/tests/unit/test_flow_builder_intra_evc.py
+++ b/tests/unit/test_flow_builder_intra_evc.py
@@ -3,7 +3,8 @@
 from unittest.mock import MagicMock
 from napps.kytos.telemetry_int.managers.flow_builder import FlowBuilder
 from napps.kytos.telemetry_int.managers.int import INTManager
-from napps.kytos.telemetry_int.utils import ProxyPort, get_cookie
+from napps.kytos.telemetry_int.utils import get_cookie
+from napps.kytos.telemetry_int.proxy_port import ProxyPort
 from napps.kytos.telemetry_int import settings
 from napps.kytos.telemetry_int.kytos_api_helper import _map_stored_flows_by_cookies
 from kytos.lib.helpers import get_controller_mock, get_switch_mock, get_interface_mock
@@ -15,9 +16,7 @@ def test_flow_builder_default_table_groups() -> None:
     assert FlowBuilder().table_group == {"evpl": 2, "epl": 3}
 
 
-def test_build_int_flows_intra_evpl(
-    evcs_data, intra_evc_evpl_flows_data, monkeypatch
-) -> None:
+def test_build_int_flows_intra_evpl(evcs_data, intra_evc_evpl_flows_data) -> None:
     """Test build INT flows intra EVPL.
 
                             +--------+
@@ -37,10 +36,7 @@ def test_build_int_flows_intra_evpl(
     controller = get_controller_mock()
     int_manager = INTManager(controller)
     get_proxy_port_or_raise = MagicMock()
-    monkeypatch.setattr(
-        "napps.kytos.telemetry_int.utils.get_proxy_port_or_raise",
-        get_proxy_port_or_raise,
-    )
+    int_manager.get_proxy_port_or_raise = get_proxy_port_or_raise
 
     evc_id = "3766c105686749"
     dpid_a = "00:00:00:00:00:00:00:01"
@@ -335,9 +331,7 @@ def test_build_int_flows_intra_evpl(
         assert (i, flow["flow"]) == (i, expected_flows[i]["flow"])
 
 
-def test_build_int_flows_intra_epl(
-    evcs_data, intra_evc_epl_flows_data, monkeypatch
-) -> None:
+def test_build_int_flows_intra_epl(evcs_data, intra_evc_epl_flows_data) -> None:
     """Test build INT flows intra EPL.
 
                             +--------+
@@ -357,10 +351,7 @@ def test_build_int_flows_intra_epl(
     controller = get_controller_mock()
     int_manager = INTManager(controller)
     get_proxy_port_or_raise = MagicMock()
-    monkeypatch.setattr(
-        "napps.kytos.telemetry_int.utils.get_proxy_port_or_raise",
-        get_proxy_port_or_raise,
-    )
+    int_manager.get_proxy_port_or_raise = get_proxy_port_or_raise
 
     evc_id = "3766c105686749"
     dpid_a = "00:00:00:00:00:00:00:01"

--- a/utils.py
+++ b/utils.py
@@ -2,11 +2,8 @@
 
 from napps.kytos.telemetry_int import settings
 
-from kytos.core import Controller
-
-from .exceptions import FlowsNotFound, PriorityOverflow, ProxyPortNotFound
+from .exceptions import FlowsNotFound, PriorityOverflow
 from .kytos_api_helper import get_stored_flows as _get_stored_flows
-from .proxy_port import ProxyPort
 
 
 async def get_found_stored_flows(cookies: list[int] = None) -> dict[int, list[dict]]:
@@ -48,37 +45,6 @@ def get_evc_unis(evc: dict) -> tuple[dict, dict]:
             "switch": ":".join(uni_z_split[:-1]),
         },
     )
-
-
-def get_proxy_port_or_raise(
-    controller: Controller, intf_id: str, evc_id: str
-) -> ProxyPort:
-    """Return a ProxyPort assigned to a UNI or raise."""
-
-    interface = controller.get_interface_by_id(intf_id)
-    if not interface:
-        raise ProxyPortNotFound(evc_id, f"UNI interface {intf_id} not found")
-
-    if "proxy_port" not in interface.metadata:
-        raise ProxyPortNotFound(evc_id, f"proxy_port metadata not found in {intf_id}")
-
-    source_intf = interface.switch.get_interface_by_port_no(
-        interface.metadata.get("proxy_port")
-    )
-    if not source_intf:
-        raise ProxyPortNotFound(
-            evc_id,
-            f"proxy_port of {intf_id} source interface not found",
-        )
-
-    pp = ProxyPort(controller, source_intf)
-
-    if not pp.destination:
-        raise ProxyPortNotFound(
-            evc_id,
-            f"proxy_port of {intf_id} isn't looped or destination interface not found",
-        )
-    return pp
 
 
 def add_to_apply_actions(


### PR DESCRIPTION
Closes #28 

### Summary

- Initial PR supporting covergence for a (looped) link used as a proxy port
- started handling proxy port link_up|link_down events
- started handling mef_eline loaded event
- extracted a few methods to reuse flow installations/deletions
- initial dict structures to keep track of unis sources and proxy ports for subsequent PRs 

### Local Tests

I tested out on INT lab the following cases with 2 inter EVPLs (sw1 and sw6) and one intra EVPL (on sw1):

- I also performed restarts to make sure it loaded correctly 
- I shut down a loop and observed that only the expected evcs got their flows removed falling back to mef_eline flows, I also had iperf3 running to make sure traffic would still flow with a temporary drop:

```
kytos $> 2023-11-13 12:41:10,036 - INFO [kytos.napps.kytos/of_core] [main.py:701:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:17 state OFPPS_LI
NK_DOWN
2023-11-13 12:41:10,041 - INFO [kytos.napps.kytos/mef_eline] [main.py:764:handle_link_down] (thread_pool_app_15) Event handle_link_down Link(Interface('novi_port_17', 17, Switch('00:00:
00:00:00:00:00:01')), Interface('novi_port_18', 18, Switch('00:00:00:00:00:00:00:01')), f8a7b8b87861d1dca6a471610d8b0c33ce320d097d41f27286f65391a5d60cd2)
2023-11-13 12:41:10,061 - INFO [kytos.napps.kytos/of_core] [main.py:701:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:18 state OFPPS_LINK_DOWN
2023-11-13 12:41:10,067 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:56238 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=t
rue&metadata.telemetry.status=UP HTTP/1.1" 200
2023-11-13 12:41:10,067 - INFO [kytos.napps.kytos/telemetry_int] [int.py:102:handle_pp_link_down] (MainThread) Handling link_down Link(Interface('novi_port_17', 17, Switch('00:00:00:00:
00:00:00:01')), Interface('novi_port_18', 18, Switch('00:00:00:00:00:00:00:01')), f8a7b8b87861d1dca6a471610d8b0c33ce320d097d41f27286f65391a5d60cd2), removing INT flows falling back to m
ef_eline, EVC ids: ['818a626a14474b', 'ede8d068444443', 'f7dc68ef737d46']
2023-11-13 12:41:10,078 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:56252 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending&co
okie_range=12142138225658709835&cookie_range=12142138225658709835&cookie_range=12172641349652464707&cookie_range=12172641349652464707&cookie_range=12175442460871458118&cookie_range=1217
5442460871458118 HTTP/1.1" 200
2023-11-13 12:41:10,085 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_25) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: delete, force: True,  flows[0, 2]: [{'cookie': 12142138225658709835, 'cookie_mask': 18446744073709551615, 'table_id': 255}, {'cookie': 12175442460871458118, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2023-11-13 12:41:10,087 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_13) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 3]: [{'cookie': 12142138225658709835, 'cookie_mask': 18446744073709551615, 'table_id': 255}, {'cookie': 12172641349652464707, 'cookie_mask': 18446744073709551615, 'table_id': 255}, {'cookie': 12175442460871458118, 'cookie_mask':18446744073709551615, 'table_id': 255}]
2023-11-13 12:41:10,112 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:56264 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-11-13 12:41:12,102 - INFO [kytos.napps.kytos/of_lldp] [loop_manager.py:250:handle_loop_stopped] (thread_pool_app_20) LLDP loop stopped on switch: 00:00:00:00:00:00:00:01, interfaces: ['novi_port_17', 'novi_port_18'], port_numbers: [17, 18]
2023-11-13 12:41:12,115 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:56272 - "DELETE /api/kytos/topology/v3/interfaces/00%3A00%3A00%3A00%3A00%3A00%3A00%3A
01%3A17/metadata/looped HTTP/1.1" 200
kytos $>                                                                                                                                                                                 

```

```
root@int02:/home/amlight# iperf3 -c 10.22.21.3 -i 5 -t 60
Connecting to host 10.22.21.3, port 5201
[  4] local 10.22.21.2 port 56434 connected to 10.22.21.3 port 5201
[ ID] Interval           Transfer     Bandwidth       Retr  Cwnd
[  4]   0.00-5.00   sec  11.1 GBytes  19.0 Gbits/sec  1323    624 KBytes       
[  4]   5.00-10.00  sec  12.2 GBytes  20.9 Gbits/sec  778    960 KBytes       
[  4]  10.00-15.00  sec  8.54 GBytes  14.7 Gbits/sec  562    751 KBytes       
[  4]  15.00-20.00  sec  9.96 GBytes  17.1 Gbits/sec  428    634 KBytes       
[  4]  20.00-25.00  sec  11.7 GBytes  20.1 Gbits/sec  754    793 KBytes       
[  4]  25.00-30.00  sec  11.7 GBytes  20.0 Gbits/sec  646    909 KBytes       
[  4]  30.00-35.00  sec  12.3 GBytes  21.1 Gbits/sec  853    875 KBytes       
[  4]  35.00-40.00  sec  10.4 GBytes  17.9 Gbits/sec  753    492 KBytes       
[  4]  40.00-45.00  sec  10.0 GBytes  17.2 Gbits/sec  1061    884 KBytes       
[  4]  45.00-50.00  sec  9.51 GBytes  16.3 Gbits/sec  409    650 KBytes       
[  4]  50.00-55.00  sec  12.6 GBytes  21.7 Gbits/sec  956    571 KBytes       
[  4]  55.00-60.00  sec  12.0 GBytes  20.7 Gbits/sec  638    773 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-60.00  sec   132 GBytes  18.9 Gbits/sec  9161             sender
[  4]   0.00-60.00  sec   132 GBytes  18.9 Gbits/sec                  receiver

iperf Done.
```

- I brought the loop up again and observed that it deployed again:

```
kytos $> 2023-11-13 12:41:35,266 - INFO [kytos.napps.kytos/of_core] [main.py:701:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:18 state OFPPS_LI
VE
2023-11-13 12:41:35,500 - INFO [kytos.napps.kytos/of_core] [main.py:701:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:17 state OFPPS_LIVE
2023-11-13 12:41:36,452 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:51852 - "POST /api/kytos/topology/v3/interfaces/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01
%3A17/metadata HTTP/1.1" 201
2023-11-13 12:41:37,511 - INFO [kytos.napps.kytos/mef_eline] [main.py:729:handle_link_up] (thread_pool_app_20) Event handle_link_up Link(Interface('novi_port_17', 17, Switch('00:00:00:0
0:00:00:00:01')), Interface('novi_port_18', 18, Switch('00:00:00:00:00:00:00:01')), f8a7b8b87861d1dca6a471610d8b0c33ce320d097d41f27286f65391a5d60cd2)
2023-11-13 12:41:37,519 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:51866 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
2023-11-13 12:41:37,527 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:51876 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
2023-11-13 12:41:42,522 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:51892 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=t
rue&metadata.telemetry.status=DOWN HTTP/1.1" 200
2023-11-13 12:41:42,523 - INFO [kytos.napps.kytos/telemetry_int] [int.py:177:handle_pp_link_up] (MainThread) Handling link_up Link(Interface('novi_port_17', 17, Switch('00:00:00:00:00:0
0:00:01')), Interface('novi_port_18', 18, Switch('00:00:00:00:00:00:00:01')), f8a7b8b87861d1dca6a471610d8b0c33ce320d097d41f27286f65391a5d60cd2), deploying EVC ids: ['818a626a14474b', 'e
de8d068444443', 'f7dc68ef737d46']
2023-11-13 12:41:42,533 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:51894 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HT
TP/1.1" 200
2023-11-13 12:41:42,544 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_25) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command
: add, force: True,  flows[0, 24]: [{'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'match': {'in_port': 15, 'dl_vlan': 2221, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 
'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instr
uction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'match': {'in_port': 15, 'dl_vlan': 2221, 'dl_type': 2048, 'nw_proto': 17}, 'tab
le_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}
]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'match': {'in_port': 15, 'dl_vlan': 2221}, 'table_id': 2, 'table_grou
p': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_typ
e': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'matc
h': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'inst
ruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'm
atch': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'
instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835
, 'match': {'in_port': 18, 'dl_vlan': 1}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_act
ions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'match': {'in_port':
 18, 'dl_vlan': 1}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'a
ction_type': 'pop_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port': 15, 'dl_
vlan': 100, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_
actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port':
 15, 'dl_vlan': 100, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type
': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {
'in_port': 15, 'dl_vlan': 100}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'ac
tions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 19}]}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port': 16, 'dl_vlan': 1
00, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions'
, 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port': 16, 'dl
_vlan': 100, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'appl
y_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port
': 16, 'dl_vlan': 100}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': 
[{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port': 20, 'dl_vlan': 100}, 'ta
ble_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_repo
rt'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port': 20, 'dl_vlan': 100}, 'table_id': 2, 'table_g
roup': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 's
et_vlan', 'vlan_id': 100}, {'action_type': 'output', 'port': 16}]}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port': 18, 'dl_vlan': 100}, 'table_id': 0,
 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'i
nstruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12172641349652464707, 'match': {'in_port': 18, 'dl_vlan': 100}, 'table_id': 2, 'table_group': 'evp
l', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'set_vlan', '
vlan_id': 100}, {'action_type': 'output', 'port': 15}]}]}, {'owner': 'telemetry_int', 'cookie': 12175442460871458118, 'match': {'in_port': 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_prot
o': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type':
 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12175442460871458118, 'match': {'in_port': 15, 'dl_vlan': 2222, 'dl_type': 2048
, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'ac
tion_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12175442460871458118, 'match': {'in_port': 15, 'dl_vlan': 2222}, 'ta
ble_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_m
etadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 2}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int', 'cookie': 1217
5442460871458118, 'match': {'in_port': 11, 'dl_vlan': 2, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 
'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_int', 'cookie': 1
2175442460871458118, 'match': {'in_port': 11, 'dl_vlan': 2, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout':
 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_int', 'cookie
': 12175442460871458118, 'match': {'in_port': 18, 'dl_vlan': 2}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instru
ction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 1217544246087145811
8, 'match': {'in_port': 18, 'dl_vlan': 2}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_ac
tions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}]
2023-11-13 12:41:42,567 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_13) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command
: add, force: True,  flows[0, 14]: [{'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'match': {'in_port': 22, 'dl_vlan': 2221, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 
'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instr
uction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'match': {'in_port': 22, 'dl_vlan': 2221, 'dl_type': 2048, 'nw_proto': 17}, 'tab
le_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}
]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'match': {'in_port': 22, 'dl_vlan': 2221}, 'table_id': 2, 'table_grou
p': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_typ
e': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'matc
h': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'inst
ruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'm
atch': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'
instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835
, 'match': {'in_port': 26, 'dl_vlan': 1}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_act
ions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12142138225658709835, 'match': {'in_port':
 26, 'dl_vlan': 1}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'a
ction_type': 'pop_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 22}]}]}, {'owner': 'telemetry_int', 'cookie': 12175442460871458118, 'match': {'in_port': 22, 'dl_
vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply
_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12175442460871458118, 'match': {'in_port'
: 22, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_ty
pe': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12175442460871458118, 'match':
 {'in_port': 22, 'dl_vlan': 2222}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 
'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 2}, {'action_type': 'output', 'port': 11}]}]}, {'o
wner': 'telemetry_int', 'cookie': 12175442460871458118, 'match': {'in_port': 11, 'dl_vlan': 2, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 
'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, 
{'owner': 'telemetry_int', 'cookie': 12175442460871458118, 'match': {'in_port': 11, 'dl_vlan': 2, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 201
00, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}
]}, {'owner': 'telemetry_int', 'cookie': 12175442460871458118, 'match': {'in_port': 26, 'dl_vlan': 2}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_
timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemet
ry_int', 'cookie': 12175442460871458118, 'match': {'in_port': 26, 'dl_vlan': 2}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instruct
ions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 22}]}]}]
2023-11-13 12:41:42,633 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:51900 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
kytos $>                                                                                                                                                                                 

```

- Observed iperf3 data transfer after no network convergence was going on too:

```
root@int02:/home/amlight# iperf3 -c 10.22.21.3 -i 5 -t 60
Connecting to host 10.22.21.3, port 5201
[  4] local 10.22.21.2 port 56440 connected to 10.22.21.3 port 5201
[ ID] Interval           Transfer     Bandwidth       Retr  Cwnd
[  4]   0.00-5.00   sec  11.6 GBytes  20.0 Gbits/sec  1387    877 KBytes       
[  4]   5.00-10.00  sec  12.6 GBytes  21.7 Gbits/sec  796    833 KBytes       
[  4]  10.00-15.00  sec  11.8 GBytes  20.2 Gbits/sec  671    867 KBytes       
[  4]  15.00-20.00  sec  11.4 GBytes  19.5 Gbits/sec  647    912 KBytes       
[  4]  20.00-25.00  sec  11.5 GBytes  19.8 Gbits/sec  592    788 KBytes       
[  4]  25.00-30.00  sec  13.1 GBytes  22.5 Gbits/sec  901    588 KBytes       
[  4]  30.00-35.00  sec  11.4 GBytes  19.6 Gbits/sec  656    629 KBytes       
[  4]  35.00-40.00  sec  11.2 GBytes  19.2 Gbits/sec  598    645 KBytes       
[  4]  40.00-45.00  sec  12.5 GBytes  21.4 Gbits/sec  765    506 KBytes       
[  4]  45.00-50.00  sec  11.5 GBytes  19.7 Gbits/sec  674    547 KBytes       
[  4]  50.00-55.00  sec  11.2 GBytes  19.3 Gbits/sec  746    676 KBytes       
[  4]  55.00-60.00  sec  12.8 GBytes  21.9 Gbits/sec  775    983 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-60.00  sec   142 GBytes  20.4 Gbits/sec  9208             sender
[  4]   0.00-60.00  sec   142 GBytes  20.4 Gbits/sec                  receiver

```

### End-to-End Tests

N/A yet