### PR TITLE
feat: replaced `kytos/mef_eline.loaded` with `kytos/mef_eline.evcs_loaded`

### DIFF
--- a/main.py
+++ b/main.py
@@ -202,15 +202,10 @@ class Main(KytosNApp):
         make the change."""
         return JSONResponse({})
 
-    @alisten_to("kytos/mef_eline.loaded")
-    async def on_mef_eline_loaded(self, _event: KytosEvent) -> None:
-        """Handle kytos/mef_eline.loaded.
-
-        In the future api.get_evcs request will get replaced via a new event TODO
-        https://github.com/kytos-ng/telemetry_int/issues/66
-        """
-        evcs = await api.get_evcs(archived=False)
-        self.int_manager.load_uni_src_proxy_ports(evcs)
+    @alisten_to("kytos/mef_eline.evcs_loaded")
+    async def on_mef_eline_evcs_loaded(self, event: KytosEvent) -> None:
+        """Handle kytos/mef_eline.evcs_loaded."""
+        self.int_manager.load_uni_src_proxy_ports(event.content)
 
     @alisten_to("kytos/of_multi_table.enable_table")
     async def on_table_enabled(self, event):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -142,3 +142,11 @@ class TestMain:
         assert api_mock_int.get_stored_flows.call_count == 1
         assert api_mock_int.add_evcs_metadata.call_count == 1
         assert self.napp.int_manager._remove_int_flows.call_count == 1
+
+    async def test_on_mef_eline_evcs_loaded(self):
+        """Test on_mef_eline_evcs_loaded."""
+        evcs = {"1": {}, "2": {}}
+        event = KytosEvent(content=evcs)
+        self.napp.int_manager = MagicMock()
+        await self.napp.on_mef_eline_evcs_loaded(event)
+        self.napp.int_manager.load_uni_src_proxy_ports.assert_called_with(evcs)


### PR DESCRIPTION
Closes #66 

This PR is on top of PR #67

This PR depends on https://github.com/kytos-ng/mef_eline/pull/401

### Summary

- feat: replaced `kytos/mef_eline.loaded` with `kytos/mef_eline.evcs_loaded`
- This NApp hasn't been released yet no need to update changelog

### Local Tests

- Created with INT EVCs and restarted, the expected `srcs_pp` (source proxy ports) were correctly loaded too:

```

kytos $> controller.napps[('kytos', 'telemetry_int')].int_manager.srcs_pp                                                                                                                
    ...:                                                                                                                                                                                 
Out[1]: 
{'00:00:00:00:00:00:00:01:5': ProxyPort(Interface('s1-eth5', 5, Switch('00:00:00:00:00:00:00:01')), Interface('s1-eth6', 6, Switch('00:00:00:00:00:00:00:01')), EntityStatus.UP),
 '00:00:00:00:00:00:00:01:7': ProxyPort(Interface('s1-eth7', 7, Switch('00:00:00:00:00:00:00:01')), Interface('s1-eth8', 8, Switch('00:00:00:00:00:00:00:01')), EntityStatus.UP),
 '00:00:00:00:00:00:00:03:5': ProxyPort(Interface('s3-eth5', 5, Switch('00:00:00:00:00:00:00:03')), Interface('s3-eth6', 6, Switch('00:00:00:00:00:00:00:03')), EntityStatus.UP)}

kytos $> srcs_pp = controller.napps[('kytos', 'telemetry_int')].int_manager.srcs_pp                                                                                                      
    ...:                                                                                                                                                                                 

kytos $> srcs_pp['00:00:00:00:00:00:00:01:5'].evc_ids                                                                                                                                    
Out[3]: {'735fa71d2f4f4d', 'a928a2bbfb4d47'}

```

### End-to-End Tests

N/A yet