### PR TITLE
feat: subscribed to `kytos/topology.interfaces.metadata.removed` to deactivate INT falling back to `mef_eline`

### DIFF
--- a/main.py
+++ b/main.py
@@ -296,6 +296,11 @@ class Main(KytosNApp):
             evcs = {evc_id: {evc_id: evc_id}}
             await self.int_manager.remove_int_flows(evcs, metadata, force=True)
 
+    @alisten_to("kytos/topology.interfaces.metadata.removed")
+    async def on_intf_metadata_removed(self, event: KytosEvent) -> None:
+        """On interface metadata removed."""
+        await self.int_manager.handle_pp_metadata_removed(event.content["interface"])
+
     # Event-driven methods: future
     def listen_for_new_evcs(self):
         """Change newly created EVC to INT-enabled EVC based on the metadata field

--- a/managers/int.py
+++ b/managers/int.py
@@ -23,6 +23,7 @@ from napps.kytos.telemetry_int.exceptions import (
     EVCHasINT,
     EVCHasNoINT,
     FlowsNotFound,
+    ProxyPortError,
     ProxyPortStatusNotUP,
     ProxyPortDestNotFound,
     ProxyPortNotFound,
@@ -245,6 +246,7 @@ class INTManager:
 
         1 - EVC not found
         2 - EVC doesn't have INT
+        3 - ProxyPortNotFound or ProxyPortDestNotFound
 
         """
         self._validate_disable_evcs(evcs, force)
@@ -259,7 +261,11 @@ class INTManager:
             }
         }
         await self.remove_int_flows(evcs, metadata, force=force)
-        self._discard_pps_evc_ids(evcs)
+        try:
+            self._discard_pps_evc_ids(evcs)
+        except ProxyPortError:
+            if not force:
+                raise
 
     async def remove_int_flows(
         self, evcs: dict[str, dict], metadata: dict, force=False

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -150,3 +150,11 @@ class TestMain:
         self.napp.int_manager = MagicMock()
         await self.napp.on_mef_eline_evcs_loaded(event)
         self.napp.int_manager.load_uni_src_proxy_ports.assert_called_with(evcs)
+
+    async def test_on_intf_metadata_remove(self):
+        """Test on_intf_metadata_removed."""
+        intf = MagicMock()
+        event = KytosEvent(content={"interface": intf})
+        self.napp.int_manager = MagicMock()
+        await self.napp.on_intf_metadata_removed(event)
+        self.napp.int_manager.handle_pp_metadata_removed.assert_called_with(intf)


### PR DESCRIPTION
Closes #70 

This PR is on top of #68 

### Summary

- Subscribed to `kytos/topology.interfaces.metadata.removed` to deactivate INT falling back to `mef_eline`
- Additions and update will be addressed on #61 

### Local Tests

- I created two INT EVCs, and then deleted `proxy_port` metadata one UNI and observed flows getting removed, after that, I also force disabled the EVCs (used a force here since this is not the typical disabling workflow since the `proxy_port` metadata had been deleted):

```
❯ http http://localhost:8181/api/kytos/telemetry_int/v1/evc/ | jq '.[].metadata'
{
  "telemetry": {
    "enabled": true,
    "status": "UP",
    "status_reason": [],
    "status_updated_at": "2023-11-17T01:16:21"
  }
}
{
  "telemetry": {
    "enabled": true,
    "status": "UP",
    "status_reason": [],
    "status_updated_at": "2023-11-17T01:17:45"
  }
}


❯ http DELETE http://127.0.0.1:8181/api/kytos/topology/v3/interfaces/00:00:00:00:00:00:00:01:01/metadata/proxy_port
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Fri, 17 Nov 2023 01:20:57 GMT
server: uvicorn

"Operation successful"

❯ http http://localhost:8181/api/kytos/telemetry_int/v1/evc/ | jq '.[].metadata'                                   
{
  "telemetry": {
    "enabled": true,
    "status": "DOWN",
    "status_reason": [
      "proxy_port_metadata_removed"
    ],
    "status_updated_at": "2023-11-17T01:20:57"
  }
}
{
  "telemetry": {
    "enabled": true,
    "status": "DOWN",
    "status_reason": [
      "proxy_port_metadata_removed"
    ],
    "status_updated_at": "2023-11-17T01:20:57"
  }
}

```

```
2023-11-16 22:20:57,718 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47566 - "DELETE /api/kytos/topology/v3/interfaces/00%3A00%3A00%3A00%3A00%3A00%3A00%3A
01%3A01/metadata/proxy_port HTTP/1.1" 200
2023-11-16 22:20:57,729 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47574 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=t
rue&metadata.telemetry.status=UP HTTP/1.1" 200
2023-11-16 22:20:57,730 - INFO [kytos.napps.kytos/telemetry_int] [int.py:224:handle_pp_metadata_removed] (MainThread) Handling interface metadata removed on Interface('s1-eth1', 1, Swit
ch('00:00:00:00:00:00:00:01')), removing INT flows falling back to mef_eline, EVC ids: ['5b66da18f26448', '7527cbd9603d46']
2023-11-16 22:20:57,740 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47580 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending&co
okie_range=12131403108160005192&cookie_range=12131403108160005192&cookie_range=12138652127125847366&cookie_range=12138652127125847366 HTTP/1.1" 200
2023-11-16 22:20:57,758 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:47590 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
kytos $>                                                                                                                                                                                 

kytos $> 2023-11-16 22:21:09,348 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:45362 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.
enabled=true HTTP/1.1" 200
2023-11-16 22:21:09,349 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:45346 - "GET /api/kytos/telemetry_int/v1/evc/ HTTP/1.1" 200
2023-11-16 22:21:14,136 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:39042 - "GET /api/kytos/mef_eline/v2/evc/7527cbd9603d46 HTTP/1.1" 200
2023-11-16 22:21:14,137 - INFO [kytos.napps.kytos/telemetry_int] [int.py:252:disable_int] (MainThread) Disabling INT on EVC ids: ['7527cbd9603d46'], force: True
2023-11-16 22:21:14,145 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:39056 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending&co
okie_range=12138652127125847366&cookie_range=12138652127125847366 HTTP/1.1" 200
2023-11-16 22:21:14,158 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:39058 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2023-11-16 22:21:14,159 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:39032 - "POST /api/kytos/telemetry_int/v1/evc/disable HTTP/1.1" 200
2023-11-16 22:21:17,117 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:39080 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=t
rue HTTP/1.1" 200
2023-11-16 22:21:17,119 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:39066 - "GET /api/kytos/telemetry_int/v1/evc/ HTTP/1.1" 200
2023-11-16 22:21:25,251 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:34520 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=t
rue HTTP/1.1" 200
2023-11-16 22:21:25,252 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:34514 - "GET /api/kytos/telemetry_int/v1/evc/ HTTP/1.1" 200
2023-11-16 22:21:31,045 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:34526 - "GET /api/kytos/mef_eline/v2/evc/5b66da18f26448 HTTP/1.1" 200
2023-11-16 22:21:31,047 - INFO [kytos.napps.kytos/telemetry_int] [int.py:252:disable_int] (MainThread) Disabling INT on EVC ids: ['5b66da18f26448'], force: True
2023-11-16 22:21:31,056 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:34536 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending&co

```

### End-to-End Tests

N/A yet