### PR TITLE
feat: added PATCH /v1/evc/redeploy INT EVCs 

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -111,6 +111,49 @@ paths:
           description: Internal Server Error
         '503':
           description: Service unavailable
+  /v1/evc/redeploy:
+    patch:
+      summary: Redeploy INT on EVCs
+      operationId: redeploy_evcs
+      requestBody:
+        description: Redeploy INT on EVCs. If the list of evc_ids is empty, it will try to redeploy all INT EVCs.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                evc_ids:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: INT redeployed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          description: Invalid request payload
+        '409':
+          description: Conflict resource state.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResp'
+        '404':
+          description: Dependent resource (EVC, flows or ProxyPort) not found 
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResp'
+        '500':
+          description: Internal Server Error
+        '503':
+          description: Service unavailable
 
 
 components:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -39,6 +39,7 @@ class TestMain:
         endpoint = f"{self.base_endpoint}/evc/enable"
         response = await self.api_client.post(endpoint, json={"evc_ids": [evc_id]})
         assert self.napp.int_manager.enable_int.call_count == 1
+        assert self.napp.int_manager._remove_int_flows.call_count == 1
         assert response.status_code == 201
         assert response.json() == [evc_id]
 

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,7 @@ from .kytos_api_helper import get_stored_flows as _get_stored_flows
 async def get_found_stored_flows(cookies: list[int] = None) -> dict[int, list[dict]]:
     """Get stored flows ensuring that flows are found."""
     cookies = cookies or []
-    stored_flows = await _get_stored_flows()
+    stored_flows = await _get_stored_flows(cookies)
     for cookie, flows in stored_flows.items():
         if not flows:
             raise FlowsNotFound(get_id_from_cookie(cookie))


### PR DESCRIPTION
Closes #30 

### Summary

- added `PATCH /v1/evc/redeploy` INT EVCs and its openapi docs
- updated `POST /v1/evc/enable` to also remove flows upfront (same behavior as mef_eline)
- No need to update changelog since this NApp hasn't been released yet

### Local Tests

I used `Novi01` and `Novi06` and tested the following cases with `iperf3` on the hosts:

- Redeployed a single EVC, observed INT flows getting removed and installed and their counters
- Enabled EVC with force true, observed NT flows getting removed and installed and their counters
- Redeployed all EVCs with empty body, observed all got redeployed

```
kytos $> 2023-11-28 18:16:15,132 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46808 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.
enabled=true&metadata.telemetry.status=DOWN HTTP/1.1" 200
2023-11-28 18:16:15,537 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46820 - "GET /api/kytos/mef_eline/v2/evc/4d88f28422b54a HTTP/1.1" 200
2023-11-28 18:16:15,538 - INFO [kytos.napps.kytos/telemetry_int] [int.py:314:redeploy_int] (MainThread) Redeploying INT on EVC ids: ['4d88f28422b54a'], force: True
2023-11-28 18:16:15,548 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46832 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending&co
okie_range=12127499946758944074&cookie_range=12127499946758944074 HTTP/1.1" 200
2023-11-28 18:16:15,556 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_5) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command:
 delete, force: True,  flows[0, 1]: [{'cookie': 12127499946758944074, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2023-11-28 18:16:15,558 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_3) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command:
 delete, force: True,  flows[0, 1]: [{'cookie': 12127499946758944074, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2023-11-28 18:16:15,568 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46848 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending&co
okie_range=12271615134834799946&cookie_range=12271615134834799946 HTTP/1.1" 200
2023-11-28 18:16:15,571 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46810 - "PATCH /api/kytos/telemetry_int/v1/evc/redeploy HTTP/1.1" 201
2023-11-28 18:16:15,572 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_4) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command:
 add, force: True,  flows[0, 7]: [{'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match': {'in_port': 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 't
able_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruc
tion_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match': {'in_port': 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'table
_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}
, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match': {'in_port': 15, 'dl_vlan': 2222}, 'table_id': 2, 'table_group'
: 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type'
: 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match'
: {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instru
ction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'mat
ch': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'in
struction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 
'match': {'in_port': 18, 'dl_vlan': 1}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actio
ns', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match': {'in_port': 1
8, 'dl_vlan': 1}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'act
ion_type': 'pop_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}]
2023-11-28 18:16:15,577 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_11) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command
: add, force: True,  flows[0, 7]: [{'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match': {'in_port': 22, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, '
table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instru
ction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match': {'in_port': 22, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'tabl
e_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]
}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match': {'in_port': 22, 'dl_vlan': 2222}, 'table_id': 2, 'table_group
': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type
': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match
': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instr
uction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'ma
tch': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'i
nstruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074,
 'match': {'in_port': 26, 'dl_vlan': 1}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_acti
ons', 'actions': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12127499946758944074, 'match': {'in_port': 
26, 'dl_vlan': 1}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'ac
tion_type': 'pop_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 22}]}]}]
2023-11-28 18:16:16,204 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:46850 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=t
rue&metadata.telemetry.status=DOWN HTTP/1.1" 200
                                                                                                                                                                             

```

- I also ran sdntrace_cp during redeploys

```
❯ echo '{ "trace": { "switch": { "dpid": "00:00:00:00:00:00:00:01", "in_port": 15}, "eth": {"dl_type": 2048, "dl_vlan": 2222}, "ip": { "nw_proto": 6 } } }' | http PUT http://127.0.0.1:81
81/api/amlight/sdntrace_cp/v1/trace
HTTP/1.1 200 OK
content-length: 369
content-type: application/json
date: Tue, 28 Nov 2023 21:19:37 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 15,
            "time": "2023-11-28 18:19:37.228428",
            "type": "starting",
            "vlan": 2222
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 11,
            "time": "2023-11-28 18:19:37.228474",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "out": {
                "port": 22,
                "vlan": 2222
            },
            "port": 26,
            "time": "2023-11-28 18:19:37.228486",
            "type": "last",
            "vlan": 1
        }
    ]
}
```

### End-to-End Tests

N/A yet
