### PR TITLE
chore: removed tmp link up sleep

### DIFF
--- a/managers/int.py
+++ b/managers/int.py
@@ -128,13 +128,6 @@ class INTManager:
         if not pp or not pp.evc_ids:
             return
 
-        # This sleep is to wait for at least a few seconds to ensure that the other
-        # proxy port would also have been considered up since the request
-        # on topology setting metadata might end up delaying, check out issue
-        # https://github.com/kytos-ng/of_lldp/issues/100
-        # TODO this will be optimized later on before releasing this NApp
-        await asyncio.sleep(5)
-
         async with self._topo_link_lock:
             if link.status != EntityStatus.UP or link.status_reason:
                 return

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -167,7 +167,6 @@ class TestINTManager:
         """Test handle_pp_link_up."""
         int_manager = INTManager(MagicMock())
         api_mock, link_mock, pp_mock = AsyncMock(), MagicMock(), MagicMock()
-        sleep_mock = AsyncMock()
         link_mock.endpoint_a.id = "3"
         pp_mock.status = EntityStatus.UP
         link_mock.status = EntityStatus.UP
@@ -182,9 +181,6 @@ class TestINTManager:
         pp_mock.evc_ids = {evc_id}
 
         monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
-        monkeypatch.setattr(
-            "napps.kytos.telemetry_int.managers.int.asyncio.sleep", sleep_mock
-        )
         api_mock.get_evcs.return_value = {
             evc_id: {
                 "active": True,
@@ -197,7 +193,6 @@ class TestINTManager:
         int_manager._validate_map_enable_evcs = MagicMock()
 
         await int_manager.handle_pp_link_up(link_mock)
-        assert sleep_mock.call_count == 1
         assert api_mock.get_evcs.call_count == 1
         assert api_mock.get_evcs.call_args[1] == {
             "metadata.telemetry.enabled": "true",


### PR DESCRIPTION
It depends on https://github.com/kytos-ng/of_lldp/pull/101 landing first

### Summary

- Removed temporary asyncio.sleep related to https://github.com/kytos-ng/of_lldp/issues/100
- This NApp hasn't been relased yet, so no need to update changelog

### Local Tests

- Simulated proxy port going down
- Simulated both proxy ports going up

```
kytos $> 2023-12-12 16:12:21,787 - INFO [kytos.napps.kytos/of_core] [main.py:701:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:5 state OFPPS_LIV
E
2023-12-12 16:12:21,788 - INFO [kytos.napps.kytos/of_core] [main.py:701:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:03:6 state OFPPS_LIVE
2023-12-12 16:12:21,790 - INFO [kytos.napps.kytos/mef_eline] [main.py:782:handle_interface_link_up] (dynamic_single_0) Event handle_interface_link_up Interface('s3-eth5', 5, Switch('00:
00:00:00:00:00:00:03'))
2023-12-12 16:12:21,790 - INFO [kytos.napps.kytos/mef_eline] [main.py:782:handle_interface_link_up] (dynamic_single_0) Event handle_interface_link_up Interface('s3-eth6', 6, Switch('00:
00:00:00:00:00:00:03'))
2023-12-12 16:12:23,393 - INFO [kytos.napps.kytos/of_lldp] [loop_manager.py:172:set_loop_detected] (MainThread) setting looped start on Interface('s3-eth5', 5, Switch('00:00:00:00:00:00
:00:03'))
2023-12-12 16:12:24,802 - INFO [kytos.napps.kytos/mef_eline] [main.py:754:handle_link_up] (thread_pool_app_10) Event handle_link_up Link(Interface('s3-eth6', 6, Switch('00:00:00:00:00:0
0:00:03')), Interface('s3-eth5', 5, Switch('00:00:00:00:00:00:00:03')), c0fe8cb39c5d91a28891d8c81403391fda144e77ac812c22043ce3bb373f6cd2)
2023-12-12 16:12:24,813 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:43050 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
2023-12-12 16:12:24,816 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:43060 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=t
rue&metadata.telemetry.status=DOWN HTTP/1.1" 200
2023-12-12 16:12:27,663 - INFO [kytos.napps.kytos/of_core] [main.py:701:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:5 state OFPPS_LIVE
2023-12-12 16:12:27,663 - INFO [kytos.napps.kytos/of_core] [main.py:701:update_port_status] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:6 state OFPPS_LIVE
2023-12-12 16:12:27,665 - INFO [kytos.napps.kytos/mef_eline] [main.py:782:handle_interface_link_up] (dynamic_single_0) Event handle_interface_link_up Interface('s1-eth5', 5, Switch('00:
00:00:00:00:00:00:01'))
2023-12-12 16:12:27,665 - INFO [kytos.napps.kytos/mef_eline] [main.py:782:handle_interface_link_up] (dynamic_single_0) Event handle_interface_link_up Interface('s1-eth6', 6, Switch('00:
00:00:00:00:00:00:01'))
2023-12-12 16:12:29,413 - INFO [kytos.napps.kytos/of_lldp] [loop_manager.py:172:set_loop_detected] (MainThread) setting looped start on Interface('s1-eth5', 5, Switch('00:00:00:00:00:00
:00:01'))
2023-12-12 16:12:30,672 - INFO [kytos.napps.kytos/mef_eline] [main.py:754:handle_link_up] (thread_pool_app_0) Event handle_link_up Link(Interface('s1-eth5', 5, Switch('00:00:00:00:00:00
:00:01')), Interface('s1-eth6', 6, Switch('00:00:00:00:00:00:00:01')), 3bdc34e8e0ca38d7c24724d07c8282cc2c5f123cfed602f5b2eb3594c9606476)
2023-12-12 16:12:30,680 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42740 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
2023-12-12 16:12:30,682 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42744 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=t
rue&metadata.telemetry.status=DOWN HTTP/1.1" 200
2023-12-12 16:12:30,683 - INFO [kytos.napps.kytos/telemetry_int] [int.py:173:handle_pp_link_up] (MainThread) Handling link_up Link(Interface('s1-eth5', 5, Switch('00:00:00:00:00:00:00:0
1')), Interface('s1-eth6', 6, Switch('00:00:00:00:00:00:00:01')), 3bdc34e8e0ca38d7c24724d07c8282cc2c5f123cfed602f5b2eb3594c9606476), deploying INT flows, EVC ids: ['aebd54defd854b']
2023-12-12 16:12:30,692 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42750 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HT
TP/1.1" 200
2023-12-12 16:12:30,706 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:42764 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201

```

### End-to-End Tests

- N/A yet