### PR TITLE
feat: added `GET v1/evc/compare` endpoint

### DIFF
--- a/kytos_api_helper.py
+++ b/kytos_api_helper.py
@@ -3,6 +3,7 @@ other kytos napps' APIs """
 
 
 from collections import defaultdict
+from typing import Union
 
 import httpx
 from napps.kytos.telemetry_int import settings
@@ -76,17 +77,23 @@ async def get_evc(evc_id: str, exclude_archived=True) -> dict:
     retry=retry_if_exception_type(httpx.RequestError),
 )
 async def get_stored_flows(
-    cookies: list[int] = None,
+    cookies: list[Union[int, tuple[int, int]]] = None,
 ) -> dict[int, list[dict]]:
     """Get flow_manager stored_flows grouped by cookies given a list of cookies."""
     cookies = cookies or []
 
     cookie_range_args = []
     for cookie in cookies:
-        # gte cookie
-        cookie_range_args.append(cookie)
-        # lte cookie
-        cookie_range_args.append(cookie)
+        if isinstance(cookie, int):
+            # gte cookie
+            cookie_range_args.append(cookie)
+            # lte cookie
+            cookie_range_args.append(cookie)
+        elif isinstance(cookie, tuple) and len(cookie) == 2:
+            # gte cookie
+            cookie_range_args.append(cookie[0])
+            # lte cookie
+            cookie_range_args.append(cookie[1])
 
     endpoint = "stored_flows?state=installed&state=pending"
     async with httpx.AsyncClient(base_url=settings.flow_manager_api) as client:

--- a/main.py
+++ b/main.py
@@ -283,7 +283,10 @@ class Main(KytosNApp):
             log.error(exc_error)
             raise HTTPException(500, detail=exc_error)
 
-        response = self.int_manager.evc_compare(int_flows, mef_flows, evcs)
+        response = [
+            {"id": k, "name": evcs[k]["name"], "compare_reason": v} for k, v in
+            self.int_manager.evc_compare(int_flows, mef_flows, evcs).items()
+        ]
         return JSONResponse(response)
 
     @alisten_to("kytos/mef_eline.evcs_loaded")

--- a/main.py
+++ b/main.py
@@ -284,8 +284,8 @@ class Main(KytosNApp):
             raise HTTPException(500, detail=exc_error)
 
         response = [
-            {"id": k, "name": evcs[k]["name"], "compare_reason": v} for k, v in
-            self.int_manager.evc_compare(int_flows, mef_flows, evcs).items()
+            {"id": k, "name": evcs[k]["name"], "compare_reason": v}
+            for k, v in self.int_manager.evc_compare(int_flows, mef_flows, evcs).items()
         ]
         return JSONResponse(response)
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ Napp to deploy In-band Network Telemetry over Ethernet Virtual Circuits
 
 import asyncio
 import pathlib
-from collections import defaultdict
 from datetime import datetime
 
 import napps.kytos.telemetry_int.kytos_api_helper as api
@@ -259,14 +258,18 @@ class Main(KytosNApp):
             int_flows, mef_flows, evcs = await asyncio.gather(
                 api.get_stored_flows(
                     [
-                        settings.INT_COOKIE_PREFIX << 56,
-                        settings.INT_COOKIE_PREFIX << 56 | 0xFFFFFFFFFFFFFF,
+                        (
+                            settings.INT_COOKIE_PREFIX << 56,
+                            settings.INT_COOKIE_PREFIX << 56 | 0xFFFFFFFFFFFFFF,
+                        ),
                     ]
                 ),
                 api.get_stored_flows(
                     [
-                        settings.MEF_COOKIE_PREFIX << 56,
-                        settings.MEF_COOKIE_PREFIX << 56 | 0xFFFFFFFFFFFFFF,
+                        (
+                            settings.MEF_COOKIE_PREFIX << 56,
+                            settings.MEF_COOKIE_PREFIX << 56 | 0xFFFFFFFFFFFFFF,
+                        ),
                     ]
                 ),
                 api.get_evcs(),

--- a/main.py
+++ b/main.py
@@ -249,9 +249,10 @@ class Main(KytosNApp):
         """List and compare which INT EVCs have flows installed comparing with
         mef_eline flows and telemetry metadata. You should use this endpoint
         to confirm if both the telemetry metadata is still coherent and also
-        the minimum expected number of flows. A dict of EVCs will get returned
-        with the outcome of the comparision, only inconsistent/incoherent EVCs
-        will be returned with the reasons why.
+        the minimum expected number of flows. A list of EVCs will get returned
+        with the inconsistent INT EVCs. If you encounter any inconsistent
+        EVC you need to analyze the situation and then decide if you'd
+        like to force enable or disable INT.
         """
 
         try:

--- a/managers/int.py
+++ b/managers/int.py
@@ -512,7 +512,7 @@ class INTManager:
             if (
                 utils.has_int_enabled(evc)
                 and evc_id in mef_flows
-                and mef_flows["id"]
+                and mef_flows[evc_id]
                 and (
                     evc_id not in int_flows
                     or len(int_flows.get(evc_id, [])) < len(mef_flows["id"])

--- a/managers/int.py
+++ b/managers/int.py
@@ -518,7 +518,7 @@ class INTManager:
                     evc_id not in int_flows
                     or (
                         evc_id in int_flows
-                        and len(int_flows[evc_id]) < len(mef_flows["id"])
+                        and len(int_flows[evc_id]) < len(mef_flows[evc_id])
                     )
                 )
             ):

--- a/openapi.yml
+++ b/openapi.yml
@@ -154,6 +154,22 @@ paths:
           description: Internal Server Error
         '503':
           description: Service unavailable
+  /v1/evc/compare:
+    get:
+      summary: List compare EVCs
+      operationId: compare_evc
+      responses:
+        '200':
+          description: List and compare which INT EVCs have flows installed comparing with mef_eline flows and telemetry metadata
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/CompareResp'
+        '500':
+          description: Internal Server Error
+        '503':
+          description: Service unavailable
 
 
 components:
@@ -165,3 +181,14 @@ components:
           type: string
         code:
           type: number
+    CompareResp: # Can be referenced via '#/components/schemas/CompareResp'
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        compare_reason:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
Closes #29 

### Summary

- Added GET v1/evc/compare endpoint
- This NApp hasn't been released yet so no need to update changelog

### Local Tests

I explored the following cases on INT lab:

- Initially, no comparison inconsistencies with one INT evc:

```
❯ http http://localhost:8181/api/kytos/telemetry_int/v1/evc/compare
HTTP/1.1 200 OK
content-length: 2
content-type: application/json
date: Wed, 03 Jan 2024 20:21:06 GMT
server: uvicorn

[]
```

- I deleted with flow manager intentionally INT flows, but kept the metadata:

```
❯ http http://localhost:8181/api/kytos/telemetry_int/v1/evc/compare                                                                                           
HTTP/1.1 200 OK
content-length: 89
content-type: application/json
date: Wed, 03 Jan 2024 20:20:19 GMT
server: uvicorn

[
    {
        "compare_reason": [
            "missing_some_int_flows"
        ],
        "id": "d045774458624d",
        "name": "intra_evpl"
    }
]

```

- I reprovisioned INT metadata again, and then deleted the telemetry metadata:

```
❯ http http://localhost:8181/api/kytos/telemetry_int/v1/evc/compare
HTTP/1.1 200 OK
content-length: 95
content-type: application/json
date: Wed, 03 Jan 2024 20:22:29 GMT
server: uvicorn

[
    {
        "compare_reason": [
            "wrong_metadata_has_int_flows"
        ],
        "id": "d045774458624d",
        "name": "intra_evpl"
    }
]
```

### End-to-End Tests

N/A yet
