### PR TITLE
feat: handled kytos/topology.interfaces.metadata.added

### DIFF
--- a/main.py
+++ b/main.py
@@ -389,6 +389,11 @@ class Main(KytosNApp):
         """On interface metadata removed."""
         await self.int_manager.handle_pp_metadata_removed(event.content["interface"])
 
+    @alisten_to("kytos/topology.interfaces.metadata.added")
+    async def on_intf_metadata_added(self, event: KytosEvent) -> None:
+        """On interface metadata added."""
+        await self.int_manager.handle_pp_metadata_added(event.content["interface"])
+
     # Event-driven methods: future
     def listen_for_new_evcs(self):
         """Change newly created EVC to INT-enabled EVC based on the metadata field

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -262,9 +262,7 @@ class TestINTManager:
         await int_manager.handle_pp_metadata_added(intf_mock)
         assert api_mock.get_evcs.call_count == 1
         assert api_mock.get_evcs.call_count == 1
-        assert api_mock.get_evcs.call_args[1] == {
-            "metadata.telemetry.enabled": "true"
-        }
+        assert api_mock.get_evcs.call_args[1] == {"metadata.telemetry.enabled": "true"}
         assert int_manager.disable_int.call_count == 1
         assert int_manager.enable_int.call_count == 1
 
@@ -322,8 +320,8 @@ class TestINTManager:
         assert api_mock.get_evcs.call_args[1] == {
             "metadata.telemetry.enabled": "true",
         }
-        assert not int_manager.disable_int.call_count == 1
-        assert not int_manager.enable_int.call_count == 1
+        assert not int_manager.disable_int.call_count
+        assert not int_manager.enable_int.call_count
 
     async def test_disable_int_metadata(self, monkeypatch) -> None:
         """Test disable INT metadata args."""

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -241,6 +241,90 @@ class TestINTManager:
         assert telemetry["status_reason"] == ["proxy_port_metadata_removed"]
         assert "status_updated_at" in telemetry
 
+    async def test_handle_pp_metadata_added(self, monkeypatch):
+        """Test handle_pp_metadata_added."""
+        int_manager = INTManager(MagicMock())
+        api_mock, intf_mock, pp_mock = AsyncMock(), MagicMock(), MagicMock()
+        intf_mock.id = "some_intf_id"
+        source_id, source_port = "some_source_id", 2
+        intf_mock.metadata = {"proxy_port": source_port}
+        evc_id = "3766c105686748"
+        int_manager.unis_src[intf_mock.id] = source_id
+        int_manager.srcs_pp[source_id] = pp_mock
+        pp_mock.evc_ids = {evc_id}
+
+        assert "proxy_port" in intf_mock.metadata
+        monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
+        api_mock.get_evcs.return_value = {evc_id: {}}
+        int_manager.disable_int = AsyncMock()
+        int_manager.enable_int = AsyncMock()
+
+        await int_manager.handle_pp_metadata_added(intf_mock)
+        assert api_mock.get_evcs.call_count == 1
+        assert api_mock.get_evcs.call_count == 1
+        assert api_mock.get_evcs.call_args[1] == {
+            "metadata.telemetry.enabled": "true"
+        }
+        assert int_manager.disable_int.call_count == 1
+        assert int_manager.enable_int.call_count == 1
+
+    async def test_handle_pp_metadata_added_no_change(self, monkeypatch):
+        """Test handle_pp_metadata_added no change."""
+        int_manager = INTManager(MagicMock())
+        api_mock, intf_mock, pp_mock = AsyncMock(), MagicMock(), MagicMock()
+        intf_mock.id = "some_intf_id"
+        source_id, source_port = "some_source_id", 2
+        source_intf = MagicMock()
+        intf_mock.metadata = {"proxy_port": source_port}
+        evc_id = "3766c105686748"
+        int_manager.unis_src[intf_mock.id] = source_id
+        int_manager.srcs_pp[source_id] = pp_mock
+        pp_mock.evc_ids = {evc_id}
+
+        # Simulating that the current and new proxy_port source are the same
+        pp_mock.source = source_intf
+        intf_mock.switch.get_interface_by_port_no.return_value = source_intf
+
+        assert "proxy_port" in intf_mock.metadata
+        monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
+        api_mock.get_evcs.return_value = {evc_id: {}}
+        int_manager.disable_int = AsyncMock()
+        int_manager.enable_int = AsyncMock()
+
+        await int_manager.handle_pp_metadata_added(intf_mock)
+        assert not api_mock.get_evcs.call_count
+        assert not int_manager.disable_int.call_count
+        assert not int_manager.enable_int.call_count
+
+    async def test_handle_pp_metadata_added_no_affected(self, monkeypatch):
+        """Test handle_pp_metadata_added no affected evcs."""
+        int_manager = INTManager(MagicMock())
+        api_mock, intf_mock, pp_mock = AsyncMock(), MagicMock(), MagicMock()
+        intf_mock.id = "some_intf_id"
+        source_id, source_port = "some_source_id", 2
+        intf_mock.metadata = {"proxy_port": source_port}
+        evc_id = "3766c105686748"
+        int_manager.unis_src[intf_mock.id] = source_id
+        int_manager.srcs_pp[source_id] = pp_mock
+        pp_mock.evc_ids = {evc_id}
+
+        assert "proxy_port" in intf_mock.metadata
+        monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
+
+        # Simulating returning no EVCs that were enabled and UP
+        api_mock.get_evcs.return_value = {}
+        int_manager.disable_int = AsyncMock()
+        int_manager.enable_int = AsyncMock()
+
+        await int_manager.handle_pp_metadata_added(intf_mock)
+        assert api_mock.get_evcs.call_count == 1
+        assert api_mock.get_evcs.call_count == 1
+        assert api_mock.get_evcs.call_args[1] == {
+            "metadata.telemetry.enabled": "true",
+        }
+        assert not int_manager.disable_int.call_count == 1
+        assert not int_manager.enable_int.call_count == 1
+
     async def test_disable_int_metadata(self, monkeypatch) -> None:
         """Test disable INT metadata args."""
         controller = MagicMock()


### PR DESCRIPTION
Closes #61

### Summary

- feat: handled event ``kytos/topology.interfaces.metadata.added`` by updating (disabling and enabling) INT EVCs accordingly
- No need to update this NApp changelog yet since it's hasn't been released yet

### Local Tests

- Using AmLight INT lab with `Novi01` and `Novi06` I updated `"00:00:00:00:00:00:00:01:15"` metadata from `{"proxy_port": 17}` to `{"proxy_port: 19"}` with one INT EVC in place, it was observed that it disabled and enabled it again as expected and `sdntrace_cp` correctly traced after it:

```
kytos $> 2024-01-08 15:18:14,425 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:35286 - "POST /api/kytos/topology/v3/interfaces/00%3A00%3A00%3A00%3A00%3A00%3
A00%3A01%3A15/metadata HTTP/1.1" 201
2024-01-08 15:18:14,433 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:35300 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=tr
ue HTTP/1.1" 200
2024-01-08 15:18:14,435 - INFO [kytos.napps.kytos/telemetry_int] [int.py:269:handle_pp_metadata_added] (MainThread) Handling interface metadata updated on Interface('novi_port_15', 15, S
witch('00:00:00:00:00:00:00:01')). It'll disable the EVCs to be safe, and then try to enable again with the updated  proxy port ProxyPort(Interface('novi_port_19', 19, Switch('00:00:00:0
0:00:00:00:01')), Interface('novi_port_20', 20, Switch('00:00:00:00:00:00:00:01')), EntityStatus.UP), EVC ids: ['0b78f967e8eb45']
2024-01-08 15:18:14,435 - INFO [kytos.napps.kytos/telemetry_int] [int.py:297:disable_int] (MainThread) Disabling INT on EVC ids: ['0b78f967e8eb45'], force: True
2024-01-08 15:18:14,441 - INFO [kytos.napps.kytos/flow_manager] [main.py:545:list_stored] (AnyIO worker thread) cookie_ranges [(12108905035701218117, 12108905035701218117)]
2024-01-08 15:18:14,443 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:35302 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTT
P/1.1" 200
2024-01-08 15:18:14,450 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_10) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command:
 delete, force: True,  flows[0, 1]: [{'cookie': 12108905035701218117, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-01-08 15:18:14,451 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_1) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: 
delete, force: True,  flows[0, 1]: [{'cookie': 12108905035701218117, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-01-08 15:18:14,469 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:35306 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2024-01-08 15:18:14,471 - INFO [kytos.napps.kytos/telemetry_int] [int.py:339:enable_int] (MainThread) Enabling INT on EVC ids: ['0b78f967e8eb45'], force: True
2024-01-08 15:18:14,477 - INFO [kytos.napps.kytos/flow_manager] [main.py:545:list_stored] (AnyIO worker thread) cookie_ranges [(12253020223777073989, 12253020223777073989)]
2024-01-08 15:18:14,479 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:35314 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTT
P/1.1" 200
2024-01-08 15:18:14,484 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_6) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: 
add, force: True,  flows[0, 7]: [{'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_port': 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'tab
le_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instructio
n_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_port': 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'table_id'
: 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'i
nstruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_port': 15, 'dl_vlan': 2222}, 'table_id': 2, 'table_group': 'evp
l', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push
_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_p
ort': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_typ
e': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 19}]}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_
port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_t
ype': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 19}]}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'i
n_port': 20, 'dl_vlan': 1}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions
': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_port': 20, 'dl_vlan': 
1}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop
_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}]
2024-01-08 15:18:14,494 - INFO [kytos.napps.kytos/flow_manager] [utils.py:196:flows_to_log_info] (thread_pool_app_9) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: 
add, force: True,  flows[0, 7]: [{'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_port': 14, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'tab
le_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instructio
n_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_port': 14, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'table_id'
: 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'i
nstruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_port': 14, 'dl_vlan': 2222}, 'table_id': 2, 'table_group': 'evp
l', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push
_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_p
ort': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_typ
e': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_
port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20100, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_t
ype': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'i
n_port': 26, 'dl_vlan': 1}, 'table_id': 0, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions
': [{'action_type': 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'owner': 'telemetry_int', 'cookie': 12108905035701218117, 'match': {'in_port': 26, 'dl_vlan': 
1}, 'table_id': 2, 'table_group': 'evpl', 'priority': 20000, 'idle_timeout': 0, 'hard_timeout': 0, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop
_int'}, {'action_type': 'pop_vlan'}, {'action_type': 'output', 'port': 14}]}]}]
2024-01-08 15:18:14,526 - INFO [uvicorn.access] [httptools_impl.py:506:send] (MainThread) 127.0.0.1:35326 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
```
- Before the update tracing from `00:00:00:00:00:00:00:06` notice it was going over the loop on 17-18

```
❯ echo '{ "trace": { "switch": { "dpid": "00:00:00:00:00:00:00:06", "in_port": 14}, "eth": {"dl_type": 2048, "dl_vlan": 2222}, "ip": { "nw_proto": 6 } } }' | http PUT http://127.0.0.1:81
81/api/amlight/sdntrace_cp/v1/trace
HTTP/1.1 200 OK
content-length: 369
content-type: application/json
date: Mon, 08 Jan 2024 18:16:07 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 14,
            "time": "2024-01-08 15:16:07.416479",
            "type": "starting",
            "vlan": 2222
        },
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 11,
            "time": "2024-01-08 15:16:07.416519",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "out": {
                "port": 15,
                "vlan": 2222
            },
            "port": 18,
            "time": "2024-01-08 15:16:07.416534",
            "type": "last",
            "vlan": 1
        }
    ]
}
```

- After the update tracing from `00:00:00:00:00:00:00:06` notice it was going over the loop on 19-20

```
❯ echo '{ "trace": { "switch": { "dpid": "00:00:00:00:00:00:00:06", "in_port": 14}, "eth": {"dl_type": 2048, "dl_vlan": 2222}, "ip": { "nw_proto": 6 } } }' | http PUT http://127.0.0.1:81
81/api/amlight/sdntrace_cp/v1/trace
HTTP/1.1 200 OK
content-length: 369
content-type: application/json
date: Mon, 08 Jan 2024 18:18:53 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 14,
            "time": "2024-01-08 15:18:54.494218",
            "type": "starting",
            "vlan": 2222
        },
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 11,
            "time": "2024-01-08 15:18:54.494256",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "out": {
                "port": 15,
                "vlan": 2222
            },
            "port": 20,
            "time": "2024-01-08 15:18:54.494267",
            "type": "last",
            "vlan": 1
        }
    ]
}

```

### End-to-End Tests

N/A yet
