### PR TITLE
chore: supported py 3.11 unit tests, increased overall test cov to 90%

### DIFF
--- a/kytos_api_helper.py
+++ b/kytos_api_helper.py
@@ -1,7 +1,6 @@
 """ This module was created to be the main interface between the telemetry napp and all
 other kytos napps' APIs """
 
-
 from collections import defaultdict
 from typing import Union
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 88
 exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
-pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,duplicate-code,unnecessary-pass,import-error,attribute-defined-outside-init,invalid-name,c-extension-no-member,raise-missing-from,wrong-import-order,too-many-public-methods,protected-access
+pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,duplicate-code,unnecessary-pass,import-error,attribute-defined-outside-init,invalid-name,c-extension-no-member,raise-missing-from,wrong-import-order,too-many-public-methods,protected-access,no-member
 linters=pylint,pycodestyle,isort,black
 
 [flake8]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Conftest."""
+
 import json
 import pytest
 

--- a/tests/unit/test_kytos_api_helper.py
+++ b/tests/unit/test_kytos_api_helper.py
@@ -1,7 +1,9 @@
 """Test kytos_api_helper.py"""
+
 from httpx import Response
 from unittest.mock import AsyncMock, MagicMock
 from napps.kytos.telemetry_int.kytos_api_helper import (
+    add_evcs_metadata,
     get_evc,
     get_stored_flows,
     get_evcs,
@@ -86,3 +88,20 @@ async def test_get_stored_flows_no_cookies_filter(
     for flows in data.values():
         for flow in flows:
             assert flow["switch"] == dpid
+
+
+async def test_add_evcs_metadata(monkeypatch):
+    """test add_evcs_metadata."""
+    aclient_mock, awith_mock = AsyncMock(), MagicMock()
+    resp = "Operation successful"
+    aclient_mock.post.return_value = Response(201, json=resp, request=MagicMock())
+    awith_mock.return_value.__aenter__.return_value = aclient_mock
+    monkeypatch.setattr("httpx.AsyncClient", awith_mock)
+
+    data = await add_evcs_metadata({}, {"some_key": "some_val"})
+    assert not data
+
+    data = await add_evcs_metadata(
+        {"some_id": {"id": "some_id"}}, {"some_key": "some_val"}
+    )
+    assert data == resp

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,5 @@
 """Test utils."""
+
 import pytest
 from httpx import Response
 from unittest.mock import AsyncMock, MagicMock

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,21 @@
 [tox]
 envlist = coverage,lint
 
-
 [testenv]
-whitelist_externals = rm
-deps = -Urrequirements/dev.in
+allowlist_externals = rm
+deps = -rrequirements/dev.in
 setenv=
-    PYTHONPATH = {toxworkdir}/py39/var/lib/kytos/:{envdir}
+    PYTHONPATH = {toxworkdir}/py311/var/lib/kytos/:{envdir}
 
 
 [testenv:coverage]
 skip_install = true
-envdir = {toxworkdir}/py39
+envdir = {toxworkdir}/py311
 commands=
     python3 setup.py coverage {posargs}
 
 
 [testenv:lint]
 skip_install = true
-envdir = {toxworkdir}/py39
+envdir = {toxworkdir}/py311
 commands = python3 setup.py lint


### PR DESCRIPTION
Closes #77 

### Summary

- Supported py 3.11 on unit tests
- Increased overall test cov to 90%
- No need to update changelog for this

### Local Tests

```
---------- coverage: platform linux, python 3.11.8-final-0 -----------
Name                                        Stmts   Miss  Cover
---------------------------------------------------------------
__init__.py                                     0      0   100%
exceptions.py                                  31      4    87%
kytos_api_helper.py                            76     15    80%
main.py                                       212     87    59%
managers/__init__.py                            0      0   100%
managers/flow_builder.py                      128      3    98%
managers/int.py                               279     52    81%
proxy_port.py                                  24      3    88%
settings.py                                    12      0   100%
tests/conftest.py                              18      0   100%
tests/unit/test_flow_builder_inter_evc.py      60      0   100%
tests/unit/test_flow_builder_intra_evc.py     105      0   100%
tests/unit/test_int_manager.py                332      0   100%
tests/unit/test_kytos_api_helper.py            63      0   100%
tests/unit/test_main.py                       176      0   100%
tests/unit/test_utils.py                       76      0   100%
utils.py                                       62      0   100%
---------------------------------------------------------------
TOTAL                                        1654    164    90%

coverage: OK ✔ in 30.65 seconds
lint: install_deps> python -I -m pip install -r requirements/dev.in
lint: commands[0]> python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished black
INFO: Finished pycodestyle
INFO: Finished pylint
[isort] Skipped 3 files
:) No issues found.
  coverage: OK (30.65=setup[26.86]+cmd[3.79] seconds)
  lint: OK (31.96=setup[27.03]+cmd[4.93] seconds)
  congratulations :) (62.64 seconds)
```

### End-to-End Tests

N/A
