### PR TITLE
feat: handled kytos/mef_eline.undeployed event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Handled ``kytos/mef_eline.undeployed`` event.
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -327,6 +327,29 @@ class Main(KytosNApp):
             log.info(f"Event mef_eline.deleted on EVC id: {evc_id}")
             await self.int_manager.disable_int({evc_id: content}, force=True)
 
+    @alisten_to("kytos/mef_eline.undeployed")
+    async def on_evc_undeployed(self, event: KytosEvent) -> None:
+        """On EVC undeployed."""
+        content = event.content
+        if (
+            not content["enabled"]
+            and "metadata" in content
+            and "telemetry" in content["metadata"]
+            and content["metadata"]["telemetry"]["enabled"]
+        ):
+            metadata = {
+                "telemetry": {
+                    "enabled": True,
+                    "status": "DOWN",
+                    "status_reason": ["undeployed"],
+                    "status_updated_at": datetime.utcnow().strftime(
+                        "%Y-%m-%dT%H:%M:%S"
+                    ),
+                }
+            }
+            evcs = {content["evc_id"]: content}
+            await self.int_manager.remove_int_flows(evcs, metadata, force=True)
+
     @alisten_to("kytos/topology.link_down")
     async def on_link_down(self, event):
         """Handle topology.link_down."""

--- a/main.py
+++ b/main.py
@@ -324,7 +324,7 @@ class Main(KytosNApp):
             and content["metadata"]["telemetry"]["enabled"]
         ):
             evc_id = content["evc_id"]
-            log.info(f"Event mef_eline.deleted on EVC id: {evc_id}")
+            log.info(f"Handling mef_eline.deleted on EVC id: {evc_id}")
             await self.int_manager.disable_int({evc_id: content}, force=True)
 
     @alisten_to("kytos/mef_eline.undeployed")
@@ -347,7 +347,9 @@ class Main(KytosNApp):
                     ),
                 }
             }
-            evcs = {content["evc_id"]: content}
+            evc_id = content["evc_id"]
+            evcs = {evc_id: content}
+            log.info(f"Handling mef_eline.undeployed on EVC id: {evc_id}")
             await self.int_manager.remove_int_flows(evcs, metadata, force=True)
 
     @alisten_to("kytos/topology.link_down")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -236,6 +236,21 @@ class TestMain:
         await self.napp.on_evc_deleted(KytosEvent(content=content))
         assert self.napp.int_manager.disable_int.call_count == 1
 
+    async def test_on_evc_undeployed(self) -> None:
+        """Test on_evc_undeployed."""
+        content = {
+            "enabled": False,
+            "metadata": {"telemetry": {"enabled": False}},
+            "evc_id": "some_id",
+        }
+        self.napp.int_manager.remove_int_flows = AsyncMock()
+        await self.napp.on_evc_undeployed(KytosEvent(content=content))
+        assert self.napp.int_manager.remove_int_flows.call_count == 0
+
+        content["metadata"]["telemetry"]["enabled"] = True
+        await self.napp.on_evc_undeployed(KytosEvent(content=content))
+        assert self.napp.int_manager.remove_int_flows.call_count == 1
+
     async def test_on_link_down(self) -> None:
         """Test on link_down."""
         self.napp.int_manager.handle_pp_link_down = AsyncMock()


### PR DESCRIPTION
Closes #84 

### Summary

See updated changelog file 

### Local Tests

- Disabled an EVC which had telemetry enabled on NoviFlow lab, observed that it removed and updated metadata:

```
kytos $> 2024-04-16 12:53:11,077 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:06, command: delete, force: True,  fl
ows[0, 1]: [{'cookie': 12288710410465943630, 'cookie_mask': 18446744073709551615}]
2024-04-16 12:53:11,083 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60582 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A06 HTTP/1.1" 202
2024-04-16 12:53:11,085 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1]
: [{'cookie': 12288710410465943630, 'cookie_mask': 18446744073709551615}]
2024-04-16 12:53:11,091 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60586 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-04-16 12:53:11,094 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60568 - "PATCH /api/kytos/mef_eline/v2/evc/8a45028b77a04e HTTP/1.1" 200
2024-04-16 12:53:11,094 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.undeployed on EVC id: 8a45028b77a04e
2024-04-16 12:53:11,110 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60600 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-16 12:53:11,119 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_9) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12144595222390087758, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-16 12:53:11,120 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_7) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12144595222390087758, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-16 12:53:11,130 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60616 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
kytos $> 


❯ http http://localhost:8181/api/kytos/telemetry_int/v1/evc/                      
HTTP/1.1 200 OK
content-length: 943
content-type: application/json
date: Tue, 16 Apr 2024 15:53:48 GMT
server: uvicorn

{
    "8a45028b77a04e": {
        "active": false,
        "archived": false,
        "backup_links": [],
        "backup_path": [],
        "bandwidth": 0,
        "circuit_scheduler": [],
        "creation_time": "2024-04-16T15:52:13",
        "current_path": [],
        "dynamic_backup_path": true,
        "enabled": false,
        "end_date": null,
        "execution_rounds": 0,
        "failover_path": [],
        "flow_removed_at": "2024-04-16T15:53:11",
        "id": "8a45028b77a04e",
        "metadata": {
            "telemetry": {
                "enabled": true,
                "status": "DOWN",
                "status_reason": [
                    "undeployed"
                ],
                "status_updated_at": "2024-04-16T15:53:11"
            }
        },
        "name": "inter_evpl_2222",
        "owner": null,
        "primary_constraints": {},
        "primary_links": [],
        "primary_path": [],
        "queue_id": -1,
        "request_time": "2024-04-16T15:52:13",
        "sb_priority": null,
        "secondary_constraints": {},
        "service_level": 6,
        "start_date": "2024-04-16T15:52:13",
        "uni_a": {
            "interface_id": "00:00:00:00:00:00:00:01:15",
            "tag": {
                "tag_type": "vlan",
                "value": 2222
            }
        },
        "uni_z": {
            "interface_id": "00:00:00:00:00:00:00:06:22",
            "tag": {
                "tag_type": "vlan",
                "value": 2222
            }
        },
        "updated_at": "2024-04-16T15:53:42"
    }
}

```

### End-to-End Tests

N/A yet