### PR TITLE
feat: handled kytos/mef_eline.(redeployed_link_down|redeployed_link_up)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ file.
 Added
 =====
 - Handled ``kytos/mef_eline.undeployed`` event.
+- Handled ``kytos/mef_eline.(redeployed_link_down|redeployed_link_up)`` event.
+- Handled ``kytos/mef_eline.error_redeploy_link_down`` event.
 
 [2023.2.0] - 2024-02-16
 ***********************

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -251,6 +251,36 @@ class TestMain:
         await self.napp.on_evc_undeployed(KytosEvent(content=content))
         assert self.napp.int_manager.remove_int_flows.call_count == 1
 
+    async def test_on_evc_redeployed_link(self) -> None:
+        """Test on redeployed_link_down|redeployed_link_up."""
+        content = {
+            "enabled": True,
+            "metadata": {"telemetry": {"enabled": False}},
+            "evc_id": "some_id",
+        }
+        self.napp.int_manager.redeploy_int = AsyncMock()
+        await self.napp.on_evc_redeployed_link(KytosEvent(content=content))
+        assert self.napp.int_manager.redeploy_int.call_count == 0
+
+        content["metadata"]["telemetry"]["enabled"] = True
+        await self.napp.on_evc_redeployed_link(KytosEvent(content=content))
+        assert self.napp.int_manager.redeploy_int.call_count == 1
+
+    async def test_on_evc_error_redeployed_link_down(self) -> None:
+        """Test error_redeployed_link_down."""
+        content = {
+            "enabled": True,
+            "metadata": {"telemetry": {"enabled": False}},
+            "evc_id": "some_id",
+        }
+        self.napp.int_manager.remove_int_flows = AsyncMock()
+        await self.napp.on_evc_error_redeployed_link_down(KytosEvent(content=content))
+        assert self.napp.int_manager.remove_int_flows.call_count == 0
+
+        content["metadata"]["telemetry"]["enabled"] = True
+        await self.napp.on_evc_error_redeployed_link_down(KytosEvent(content=content))
+        assert self.napp.int_manager.remove_int_flows.call_count == 1
+
     async def test_on_link_down(self) -> None:
         """Test on link_down."""
         self.napp.int_manager.handle_pp_link_down = AsyncMock()


### PR DESCRIPTION
Closes #42 

This PR is on top of PR #85 

### Summary

See updated changelog file. For more information about the [events check out EP031](https://github.com/kytos-ng/kytos/pull/468)

### Local Tests

I tested all the three subscribed events on NoviFlow lab at AmLight too:

- Handling  `mef_eline.error_redeployed_link_down`:

```
kytos $> 2024-04-17 09:40:07,043 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:06:11 state OFPPS_LINK_DOWN
2024-04-17 09:40:07,047 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) Event handle_link_down Link(Interface('novi_port_11', 11, Switch('00:00:00:00:00:00:00:01')), Interface('
novi_port_11', 11, Switch('00:00:00:00:00:00:00:06')), d7e3aade462df35a656320b717e8603a7fd624c4cfb7dcb72feafe95c6be1c96)
2024-04-17 09:40:07,047 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) evc_affected_by_link_down for b130202884e34b
2024-04-17 09:40:07,057 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1]
: [{'cookie': 12299664972002419531, 'cookie_mask': 18446744073709551615}]
2024-04-17 09:40:07,070 - INFO [uvicorn.access] (MainThread) 127.0.0.1:49564 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-04-17 09:40:07,080 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:06, command: delete, force: True,  flows[0, 1]
: [{'cookie': 12299664972002419531, 'cookie_mask': 18446744073709551615}]
2024-04-17 09:40:07,095 - INFO [uvicorn.access] (MainThread) 127.0.0.1:49568 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A06 HTTP/1.1" 202
2024-04-17 09:40:07,109 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_app_10) EVC(b130202884e34b, inter_evpl_2222) was not deployed. No available path was found.
2024-04-17 09:40:07,109 - INFO [uvicorn.access] (MainThread) 127.0.0.1:49578 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-04-17 09:40:07,113 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1]
: [{'cookie': 12299664972002419531, 'cookie_mask': 18446744073709551615}]
2024-04-17 09:40:07,118 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:11 state OFPPS_LINK_DOWN
2024-04-17 09:40:07,120 - INFO [uvicorn.access] (MainThread) 127.0.0.1:49580 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-04-17 09:40:07,129 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:06, command: delete, force: True,  flows[0, 1]
: [{'cookie': 12299664972002419531, 'cookie_mask': 18446744073709551615}]
2024-04-17 09:40:07,132 - INFO [uvicorn.access] (MainThread) 127.0.0.1:49582 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A06 HTTP/1.1" 202
2024-04-17 09:40:07,137 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.redeployed_link_down_no_path on EVC id: b130202884e34b
2024-04-17 09:40:07,146 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_37) Event handle_interface_link_down Interface('novi_port_11', 11, Switch('00:00:00:00:00:00:00:06'))
2024-04-17 09:40:07,152 - INFO [uvicorn.access] (MainThread) 127.0.0.1:49592 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-17 09:40:07,158 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_4) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12155549783926563659, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-17 09:40:07,160 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_17) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 
1]: [{'cookie': 12155549783926563659, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-17 09:40:07,168 - INFO [uvicorn.access] (MainThread) 127.0.0.1:49598 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2024-04-17 09:40:07,226 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_16) Event handle_interface_link_down Interface('novi_port_11', 11, Switch('00:00:00:00:00:00:00:01'))
kytos $> 
```

- Handling  `mef_eline.redeployed_link_down` and confirming with `sdntrace_cp`:

```
2024-04-17 09:54:43,027 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_49) Event handle_interface_link_down Interface('novi_port_11', 11, Switch('00:00:00:00:00:00:00:01'))
2024-04-17 09:54:43,029 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_24) EVC(e1368fac999142, inter_evpl_2222_static) was deployed.
2024-04-17 09:54:43,030 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_24) EVC(e1368fac999142, inter_evpl_2222_static) redeployed due to link down d7e3aade462df35a656320b717e8603
a7fd624c4cfb7dcb72feafe95c6be1c96
2024-04-17 09:54:43,030 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling kytos/mef_eline.redeployed_link_down, EVC id: e1368fac999142
2024-04-17 09:54:43,030 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Redeploying INT on EVC ids: ['e1368fac999142'], force: True
2024-04-17 09:54:43,039 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51718 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-17 09:54:43,045 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_22) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: delete, force: True,  flows[0, 
1]: [{'cookie': 12169067658835759426, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-17 09:54:43,046 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_15) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 
1]: [{'cookie': 12169067658835759426, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-17 09:54:43,052 - INFO [uvicorn.access] (MainThread) 127.0.0.1:51734 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-17 09:54:43,056 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_20) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: True,  flows[0, 7]:
 [{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 15, 'dl_
vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table
_id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port'
: 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tab
le', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match':
 {'in_port': 15, 'dl_vlan': 2222}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'},
 {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12169
067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'act
ions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 121
69067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', '
actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 
12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 18, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 's
end_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12169067658835759426, 
'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 18, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_typ
e': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}]
2024-04-17 09:54:43,063 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_53) Event handle_interface_link_down Interface('novi_port_11', 11, Switch('00:00:00:00:00:00:00:06'))
2024-04-17 09:54:43,063 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: True,  flows[0, 7]: 
[{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 14, 'dl_v
lan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_
id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port':
 14, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tabl
e', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': 
{'in_port': 14, 'dl_vlan': 2222}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, 
{'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 5}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 121690
67658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 5, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'acti
ons': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 1216
9067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 5, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'a
ctions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 1
2169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'se
nd_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12169067658835759426, '
idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type
': 'pop_vlan'}, {'action_type': 'output', 'port': 14}]}]}]
2024-04-17 09:54:43,073 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_26) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:02, command: add, force: True,  flows[0, 4]:
 [{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_v
lan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 
1}, {'action_type': 'output', 'port': 1}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'har
d_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metada
ta'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 1}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 
12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 1, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions',
 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_g
roup': 'evpl', 'priority': 20100, 'cookie': 12169067658835759426, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 1, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instruct
ions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}]
```
sdntrace_cp before link down:

```
❯ echo '{ "trace": { "switch": { "dpid": "00:00:00:00:00:00:00:01", "in_port": 15}, "eth": {"dl_type": 2048, "dl_vlan": 2222}, "ip": { "nw_proto": 6 } } }' | http PUT http://127.0.0.1:81
81/api/amlight/sdntrace_cp/v1/trace
HTTP/1.1 200 OK
content-length: 369
content-type: application/json
date: Wed, 17 Apr 2024 12:53:26 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 15,
            "time": "2024-04-17 09:53:26.988237",
            "type": "starting",
            "vlan": 2222
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 11,
            "time": "2024-04-17 09:53:26.988280",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "out": {
                "port": 14,
                "vlan": 2222
            },
            "port": 26,
            "time": "2024-04-17 09:53:26.988294",
            "type": "last",
            "vlan": 1
        }
    ]
}
```

sdntrace_cp before after down:

```
❯ echo '{ "trace": { "switch": { "dpid": "00:00:00:00:00:00:00:01", "in_port": 15}, "eth": {"dl_type": 2048, "dl_vlan": 2222}, "ip": { "nw_proto": 6 } } }' | http PUT http://127.0.0.1:81
81/api/amlight/sdntrace_cp/v1/trace
HTTP/1.1 200 OK
content-length: 479
content-type: application/json
date: Wed, 17 Apr 2024 12:55:00 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 15,
            "time": "2024-04-17 09:55:01.383143",
            "type": "starting",
            "vlan": 2222
        },
        {
            "dpid": "00:00:00:00:00:00:00:02",
            "port": 2,
            "time": "2024-04-17 09:55:01.383183",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 5,
            "time": "2024-04-17 09:55:01.383196",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "out": {
                "port": 14,
                "vlan": 2222
            },
            "port": 26,
            "time": "2024-04-17 09:55:01.383205",
            "type": "last",
            "vlan": 1
        }
    ]
}
```

- Handling  `mef_eline.redeployed_link_up` and confirming with `sdntrace_cp`:

```
2024-04-17 10:43:03,095 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_25) EVC(30fa9aa887dc43, inter_evpl_2222) was deployed.
2024-04-17 10:43:03,096 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling kytos/mef_eline.redeployed_link_up, EVC id: 30fa9aa887dc43
2024-04-17 10:43:03,091 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41336 - "POST /api/kytos/flow_manager/v2/flows/00%3A00%3A00%3A00%3A00%3A00%3A00%3A06 HTTP/1.1" 202
2024-04-17 10:43:03,096 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Redeploying INT on EVC ids: ['30fa9aa887dc43'], force: True
2024-04-17 10:43:03,103 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41344 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-17 10:43:03,110 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41356 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-17 10:43:03,111 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_16) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: True,  flows[0, 7]:
 [{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 15, 'dl_
vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table
_id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port'
: 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tab
le', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match':
 {'in_port': 15, 'dl_vlan': 2222}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'},
 {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 1211
9462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'a
ctions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 1
2119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions'
, 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie
': 12119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 18, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type':
 'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 1211946213941338835
5, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 18, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_
type': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}]
2024-04-17 10:43:03,116 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: True,  flows[0, 7]: 
[{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 22, 'dl_v
lan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_
id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port':
 22, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tabl
e', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': 
{'in_port': 22, 'dl_vlan': 2222}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, 
{'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 11}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12119
462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'ac
tions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12
119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 11, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions',
 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie'
: 12119462139413388355, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 
'send_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12119462139413388355
, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_t
ype': 'pop_vlan'}, {'action_type': 'output', 'port': 22}]}]}]
2024-04-17 10:43:04,951 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_4) Event handle_link_up Link(Interface('novi_port_2', 2, Switch('00:00:00:00:00:00:00:01')), Interface('nov
i_port_2', 2, Switch('00:00:00:00:00:00:00:02')), cf0f4071be426b3f745027f5d22bc61f8312ae86293c9b28e7e66015607a9260)
2024-04-17 10:43:04,958 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41360 - "GET /api/kytos/topology/v3/links HTTP/1.1" 200
kytos $> 
```


### End-to-End Tests

N/A yet