### PR TITLE
fix: only raise FlowsNotFound when it's active and flows aren't found

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Added
 - Handled ``kytos/mef_eline.(redeployed_link_down|redeployed_link_up)`` event.
 - Handled ``kytos/mef_eline.error_redeploy_link_down`` event.
 
+Changed
+=======
+- Only raise ``FlowsNotFound`` when an EVC is active and flows aren't found. Update status and status_reason accordingly too when installing flows.
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -73,6 +73,8 @@ class FlowBuilder:
                 break
 
         if not new_int_flow_tbl_0_tcp:
+            if not evc["active"]:
+                return []
             raise FlowsNotFound(evc["id"])
 
         utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
@@ -222,6 +224,8 @@ class FlowBuilder:
             new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
 
             if not new_int_flow_tbl_0_tcp:
+                if not evc["active"]:
+                    return []
                 raise FlowsNotFound(evc["id"])
 
             utils.set_new_cookie(new_int_flow_tbl_0_tcp)

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -359,12 +359,18 @@ class TestINTManager:
 
         int_manager = INTManager(controller)
         int_manager.remove_int_flows = AsyncMock()
-        await int_manager.enable_int({}, False)
+        evcs = {"3766c105686749": {"active": True}}
+        int_manager._validate_map_enable_evcs = MagicMock()
+        int_manager._validate_map_enable_evcs.return_value = evcs
+        int_manager.flow_builder.build_int_flows = MagicMock()
+        int_manager.flow_builder.build_int_flows.return_value = {}
+        int_manager._add_pps_evc_ids = MagicMock()
+
+        await int_manager.enable_int(evcs, False)
 
         assert stored_flows_mock.call_count == 1
-        assert api_mock.add_evcs_metadata.call_count == 1
+        assert api_mock.add_evcs_metadata.call_count == 2
         args = api_mock.add_evcs_metadata.call_args[0]
-        assert args[0] == {}
         assert "telemetry" in args[1]
         telemetry_dict = args[1]["telemetry"]
         expected_keys = ["enabled", "status", "status_reason", "status_updated_at"]


### PR DESCRIPTION
Closes #87 

This is on top of PR #86 

### Summary

See updated changelog file

### Local Tests

I tested on AmLight INT Lab the following cases 

- Enabled INT on an inactive EVC, observed metadata was updated accordingly
- Enabled INT on an active EVC, observed metadata was updated accordingly

```
❯ http http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/9461d30603ae44 | jq
{
  "active": false,
  "archived": false,
  "backup_path": [],
  "bandwidth": 0,
  "circuit_scheduler": [],
  "current_path": [],
  "dynamic_backup_path": true,
  "enabled": true,
  "failover_path": [],
  "id": "9461d30603ae44",
  "metadata": {
    "telemetry": {
      "enabled": true,
      "status": "DOWN",
      "status_reason": [
        "no_flows"
      ],
      "status_updated_at": "2024-04-22T14:54:19"
    }
  },
  "name": "inter_evpl_2222",
  "primary_path": [],
  "service_level": 6,
  "uni_a": {
    "tag": {
      "tag_type": "vlan",
      "value": 2222
    },
    "interface_id": "00:00:00:00:00:00:00:01:15"
  },
  "uni_z": {
    "tag": {
      "tag_type": "vlan",
      "value": 2222
    },
    "interface_id": "00:00:00:00:00:00:00:06:22"
  },
  "sb_priority": null,
  "execution_rounds": 0,
  "owner": null,
  "queue_id": -1,
  "primary_constraints": {},
  "secondary_constraints": {},
  "primary_links": [],
  "backup_links": [],
  "start_date": "2024-04-22T13:32:18",
  "creation_time": "2024-04-22T13:32:18",
  "request_time": "2024-04-22T13:32:18",
  "end_date": null,
  "flow_removed_at": "2024-04-22T13:34:00",
  "updated_at": "2024-04-22T14:53:54"
}

```

```
❯ http http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/9461d30603ae44 | jq
{
  "active": true,
  "archived": false,
  "backup_path": [],
  "bandwidth": 0,
  "circuit_scheduler": [],
  "current_path": [
    {
      "id": "d7e3aade462df35a656320b717e8603a7fd624c4cfb7dcb72feafe95c6be1c96",
      "endpoint_a": {
        "id": "00:00:00:00:00:00:00:01:11",
        "name": "novi_port_11",
        "port_number": 11,
        "mac": "00:00:00:00:00:00",
        "switch": "00:00:00:00:00:00:00:01",
        "type": "interface",
        "nni": true,
        "uni": false,
        "speed": 12500000000.0,
        "metadata": {},
        "lldp": true,
        "active": true,
        "enabled": true,
        "status": "UP",
        "status_reason": [],
        "link": "d7e3aade462df35a656320b717e8603a7fd624c4cfb7dcb72feafe95c6be1c96"
      },
      "endpoint_b": {
        "id": "00:00:00:00:00:00:00:06:11",
        "name": "novi_port_11",
        "port_number": 11,
        "mac": "00:00:00:00:00:00",
        "switch": "00:00:00:00:00:00:00:06",
        "type": "interface",
        "nni": true,
        "uni": false,
        "speed": 12500000000.0,
        "metadata": {},
        "lldp": true,
        "active": true,
        "enabled": true,
        "status": "UP",
        "status_reason": [],
        "link": "d7e3aade462df35a656320b717e8603a7fd624c4cfb7dcb72feafe95c6be1c96"
      },
      "metadata": {
        "s_vlan": {
          "tag_type": "vlan",
          "value": 1
        }
      },
      "active": true,
      "enabled": true,
      "status": "UP",
      "status_reason": []
    }
  ],
  "dynamic_backup_path": true,
  "enabled": true,
  "failover_path": [],
  "id": "9461d30603ae44",
  "metadata": {
    "telemetry": {
      "enabled": true,
      "status": "UP",
      "status_reason": [],
      "status_updated_at": "2024-04-22T14:55:15"
    }
  },
  "name": "inter_evpl_2222",
  "primary_path": [],
  "service_level": 6,
  "uni_a": {
    "tag": {
      "tag_type": "vlan",
      "value": 2222
    },
    "interface_id": "00:00:00:00:00:00:00:01:15"
  },
  "uni_z": {
    "tag": {
      "tag_type": "vlan",
      "value": 2222
    },
    "interface_id": "00:00:00:00:00:00:00:06:22"
  },
  "sb_priority": null,
  "execution_rounds": 0,
  "owner": null,
  "queue_id": -1,
  "primary_constraints": {},
  "secondary_constraints": {},
  "primary_links": [],
  "backup_links": [],
  "start_date": "2024-04-22T13:32:18",
  "creation_time": "2024-04-22T13:32:18",
  "request_time": "2024-04-22T13:32:18",
  "end_date": null,
  "flow_removed_at": "2024-04-22T14:53:54",
  "updated_at": "2024-04-22T14:55:21"
}

```

### End-to-End Tests

N/A yet.