### PR TITLE
feat: handled kytos/mef_eline.uni_active_updated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 - Handled ``kytos/mef_eline.undeployed`` event.
 - Handled ``kytos/mef_eline.(redeployed_link_down|redeployed_link_up)`` event.
 - Handled ``kytos/mef_eline.error_redeploy_link_down`` event.
+- Handled ``kytos/mef_eline.uni_active_updated`` event.
 
 Changed
 =======

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,10 @@ Subscribed
 - ``kytos/of_multi_table.enable_table``
 - ``kytos/mef_eline.deleted``
 - ``kytos/flow_manager.flow.error``
+- ``kytos/mef_eline.undeployed``
+- ``kytos/mef_eline.(redeployed_link_down|redeployed_link_up)``
+- ``kytos/mef_eline.error_redeploy_link_down``
+- ``kytos/mef_eline.uni_active_updated``
 
 Published
 ---------

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -236,6 +236,29 @@ class TestMain:
         await self.napp.on_evc_deleted(KytosEvent(content=content))
         assert self.napp.int_manager.disable_int.call_count == 1
 
+    async def test_on_uni_active_updated(self, monkeypatch) -> None:
+        """Test on UNI active updated."""
+        api_mock = AsyncMock()
+        monkeypatch.setattr(
+            "napps.kytos.telemetry_int.main.api",
+            api_mock,
+        )
+        content = {
+            "metadata": {"telemetry": {"enabled": True}},
+            "evc_id": "some_id",
+            "active": True,
+        }
+        await self.napp.on_uni_active_updated(KytosEvent(content=content))
+        assert api_mock.add_evcs_metadata.call_count == 1
+        args = api_mock.add_evcs_metadata.call_args[0][1]
+        assert args["telemetry"]["status"] == "UP"
+
+        content["active"] = False
+        await self.napp.on_uni_active_updated(KytosEvent(content=content))
+        assert api_mock.add_evcs_metadata.call_count == 2
+        args = api_mock.add_evcs_metadata.call_args[0][1]
+        assert args["telemetry"]["status"] == "DOWN"
+
     async def test_on_evc_undeployed(self) -> None:
         """Test on_evc_undeployed."""
         content = {


### PR DESCRIPTION
Closes #89 

This is on top of PR #88

### Summary

See updated changelog file 

### Local Tests

- Tested on AmLight INT lab with two EVCs and flapping the UNI state:

```
kytos $> 2024-04-24 15:17:21,170 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:15 state OFPPS_LINK_DOWN
2024-04-24 15:17:21,272 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_56) Event handle_interface_link_down Interface('novi_port_15', 15, Switch('00:00:00:00:00:00:00:01'))
2024-04-24 15:17:21,273 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_56) Deactivating EVC 5608a913b43c4b. Interfaces: {'00:00:00:00:00:00:00:01:15': {'status': 'DOWN', 'status_r
eason': {'deactivated'}}}.
2024-04-24 15:17:21,278 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.uni_active_updated active False on EVC id: 5608a913b43c4b
2024-04-24 15:17:21,284 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_56) Deactivating EVC 2d097665300b4f. Interfaces: {'00:00:00:00:00:00:00:01:15': {'status': 'DOWN', 'status_r
eason': {'deactivated'}}}.
2024-04-24 15:17:21,295 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.uni_active_updated active False on EVC id: 2d097665300b4f
2024-04-24 15:17:21,315 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60434 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2024-04-24 15:17:21,318 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60450 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2024-04-24 15:17:27,258 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58706 - "GET /api/kytos/mef_eline/v2/evc/5608a913b43c4b HTTP/1.1" 200
2024-04-24 15:17:39,385 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:15 state OFPPS_LIVE
2024-04-24 15:17:39,488 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_8) Event handle_interface_link_up Interface('novi_port_15', 15, Switch('00:00:00:00:00:00:00:01'))
2024-04-24 15:17:39,488 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_8) Activating EVC 5608a913b43c4b. Interfaces: {'00:00:00:00:00:00:00:01:15': {'status': 'UP', 'status_reason
': set()}, '00:00:00:00:00:00:00:06:22': {'status': 'UP', 'status_reason': set()}}.
2024-04-24 15:17:39,489 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.uni_active_updated active True on EVC id: 5608a913b43c4b
2024-04-24 15:17:39,493 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_8) Event handle_interface_link_up Interface('novi_port_15', 15, Switch('00:00:00:00:00:00:00:01'))
2024-04-24 15:17:39,493 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_8) Activating EVC 2d097665300b4f. Interfaces: {'00:00:00:00:00:00:00:01:15': {'status': 'UP', 'status_reason
': set()}, '00:00:00:00:00:00:00:06:22': {'status': 'UP', 'status_reason': set()}}.
2024-04-24 15:17:39,495 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.uni_active_updated active True on EVC id: 2d097665300b4f
2024-04-24 15:17:39,505 - INFO [uvicorn.access] (MainThread) 127.0.0.1:38828 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2024-04-24 15:17:39,506 - INFO [uvicorn.access] (MainThread) 127.0.0.1:38836 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201

```


```

❯ http http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/5608a913b43c4b | jq '.metadata, .active' 
{
  "telemetry": {
    "enabled": true,
    "status": "DOWN",
    "status_reason": [
      "uni_down"
    ],
    "status_updated_at": "2024-04-24T18:17:21"
  }
}
false


❯ http http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/5608a913b43c4b | jq '.metadata, .active' 
{
  "telemetry": {
    "enabled": true,
    "status": "UP",
    "status_reason": [],
    "status_updated_at": "2024-04-24T18:17:39"
  }
}
true

```

### End-to-End Tests
