### PR TITLE
feat: subscribed and handled kytos/mef_eline.deployed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 - Handled ``kytos/mef_eline.(redeployed_link_down|redeployed_link_up)`` event.
 - Handled ``kytos/mef_eline.error_redeploy_link_down`` event.
 - Handled ``kytos/mef_eline.uni_active_updated`` event.
+- Handled ``kytos/mef_eline.deployed`` event.
 
 Changed
 =======

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ Subscribed
 - ``kytos/mef_eline.(redeployed_link_down|redeployed_link_up)``
 - ``kytos/mef_eline.error_redeploy_link_down``
 - ``kytos/mef_eline.uni_active_updated``
+- ``kytos/mef_eline.deployed``
 
 Published
 ---------

--- a/main.py
+++ b/main.py
@@ -333,6 +333,7 @@ class Main(KytosNApp):
         """On EVC deployed."""
         content = event.content
         evc_id = content["evc_id"]
+        content["id"] = evc_id
         evcs = {evc_id: content}
         try:
             if (

--- a/main.py
+++ b/main.py
@@ -328,6 +328,33 @@ class Main(KytosNApp):
             log.info(f"Handling mef_eline.deleted on EVC id: {evc_id}")
             await self.int_manager.disable_int({evc_id: content}, force=True)
 
+    @alisten_to("kytos/mef_eline.deployed")
+    async def on_evc_deployed(self, event: KytosEvent) -> None:
+        """On EVC deployed."""
+        content = event.content
+        evc_id = content["evc_id"]
+        evcs = {evc_id: content}
+        try:
+            if (
+                "metadata" in content
+                and "telemetry" in content["metadata"]
+                and content["metadata"]["telemetry"]["enabled"]
+            ):
+                log.info(f"Handling mef_eline.deployed on EVC id: {evc_id}")
+                await self.int_manager.redeploy_int(evcs)
+            elif (
+                "metadata" in content
+                and "telemetry_request" in content["metadata"]
+                and "telemetry" not in content["metadata"]
+            ):
+                log.info(f"Handling mef_eline.deployed on EVC id: {evc_id}")
+                await self.int_manager.enable_int(evcs, force=True)
+        except EVCError as exc:
+            log.error(
+                f"Failed when handling mef_eline.deployed: {exc}. Analyze the error "
+                f"and you'll need to enable or redeploy EVC {evc_id} later"
+            )
+
     @alisten_to("kytos/mef_eline.undeployed")
     async def on_evc_undeployed(self, event: KytosEvent) -> None:
         """On EVC undeployed."""

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -359,7 +359,13 @@ class TestINTManager:
 
         int_manager = INTManager(controller)
         int_manager.remove_int_flows = AsyncMock()
-        evcs = {"3766c105686749": {"active": True}}
+        evcs = {
+            "3766c105686749": {
+                "active": True,
+                "uni_a": MagicMock(),
+                "uni_z": MagicMock(),
+            }
+        }
         int_manager._validate_map_enable_evcs = MagicMock()
         int_manager._validate_map_enable_evcs.return_value = evcs
         int_manager.flow_builder.build_int_flows = MagicMock()
@@ -369,7 +375,7 @@ class TestINTManager:
         await int_manager.enable_int(evcs, False)
 
         assert stored_flows_mock.call_count == 1
-        assert api_mock.add_evcs_metadata.call_count == 2
+        assert api_mock.add_evcs_metadata.call_count == 3
         args = api_mock.add_evcs_metadata.call_args[0]
         assert "telemetry" in args[1]
         telemetry_dict = args[1]["telemetry"]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -229,6 +229,20 @@ class TestMain:
         )
         assert not self.napp.controller.buffers.app.aput.call_count
 
+    async def test_on_evc_deployed(self) -> None:
+        """Test on_evc_deployed."""
+        content = {"metadata": {"telemetry_request": {}}, "evc_id": "some_id"}
+        self.napp.int_manager.redeploy_int = AsyncMock()
+        self.napp.int_manager.enable_int = AsyncMock()
+        await self.napp.on_evc_deployed(KytosEvent(content=content))
+        assert self.napp.int_manager.enable_int.call_count == 1
+        assert self.napp.int_manager.redeploy_int.call_count == 0
+
+        content = {"metadata": {"telemetry": {"enabled": True}}, "evc_id": "some_id"}
+        await self.napp.on_evc_deployed(KytosEvent(content=content))
+        assert self.napp.int_manager.enable_int.call_count == 1
+        assert self.napp.int_manager.redeploy_int.call_count == 1
+
     async def test_on_evc_deleted(self) -> None:
         """Test on_evc_deleted."""
         content = {"metadata": {"telemetry": {"enabled": True}}, "evc_id": "some_id"}


### PR DESCRIPTION
Closes #41 

This PR is on top of PR #91 

### Summary

See updated changelog file 

### Local Tests

Tested on AmLight INT Lab:

- Created a new EVC with `telemetry_request` metadata to provision INT as soon as it got deployed:

```
2024-04-30 16:14:13,342 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35034 - "POST /api/kytos/mef_eline/v2/evc/ HTTP/1.1" 201
2024-04-30 16:14:13,342 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.deployed on EVC id: f238b121886a44
2024-04-30 16:14:13,342 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Enabling INT on EVC ids: ['f238b121886a44'], force: True
2024-04-30 16:14:13,351 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35094 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-04-30 16:14:13,353 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35098 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-30 16:14:13,355 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_app_24) Failover path for EVC(f238b121886a44, inter_evpl_2222) was not deployed: No available path was found
2024-04-30 16:14:13,361 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_8) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: True,  flows[0, 7]: 
[{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 15, 'dl_v
lan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_
id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port':
 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tabl
e', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': 
{'in_port': 15, 'dl_vlan': 2222}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, 
{'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 121738
55076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'acti
ons': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 1217
3855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'a
ctions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 1
2173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 18, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'se
nd_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12173855076158827076, '
idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 18, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type
': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}]
2024-04-30 16:14:13,366 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_17) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: True,  flows[0, 7]:
 [{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 22, 'dl_
vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table
_id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port'
: 22, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tab
le', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match':
 {'in_port': 22, 'dl_vlan': 2222}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'},
 {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 5}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173
855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 5, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'act
ions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 121
73855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 5, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', '
actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 
12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 's
end_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12173855076158827076, 
'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_typ
e': 'pop_vlan'}, {'action_type': 'output', 'port': 22}]}]}]
2024-04-30 16:14:13,376 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_22) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:02, command: add, force: True,  flows[0, 4]:
 [{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_v
lan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 
1}, {'action_type': 'output', 'port': 1}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'har
d_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metada
ta'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 1}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 
12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 1, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions',
 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_g
roup': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 1, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instruct
ions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}]
2024-04-30 16:14:13,420 - INFO [uvicorn.access] (MainThread) 127.0.0.1:35106 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
kytos $> 

```

- Redeployed an EVC on `mef_eline` and `telemetry_int` redeployed it too when handling `kytos/mef_eline.deployed`:

```
2024-04-30 16:16:39,478 - INFO [uvicorn.access] (MainThread) 127.0.0.1:34730 - "PATCH /api/kytos/mef_eline/v2/evc/f238b121886a44/redeploy HTTP/1.1" 202
2024-04-30 16:16:39,478 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.deployed on EVC id: f238b121886a44
2024-04-30 16:16:39,478 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Redeploying INT on EVC ids: ['f238b121886a44'], force: True
2024-04-30 16:16:39,488 - INFO [uvicorn.access] (MainThread) 127.0.0.1:34826 - "POST /api/kytos/pathfinder/v3/ HTTP/1.1" 200
2024-04-30 16:16:39,492 - INFO [uvicorn.access] (MainThread) 127.0.0.1:34840 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-30 16:16:39,492 - WARNING [kytos.napps.kytos/mef_eline] (thread_pool_app_23) Failover path for EVC(f238b121886a44, inter_evpl_2222) was not deployed: No available path was found
2024-04-30 16:16:39,498 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_18) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:02, command: delete, force: True,  flows[0, 
1]: [{'cookie': 12173855076158827076, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-30 16:16:39,500 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_12) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 
1]: [{'cookie': 12173855076158827076, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-30 16:16:39,503 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_1) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12173855076158827076, 'cookie_mask': 18446744073709551615, 'table_id': 255}]
2024-04-30 16:16:39,513 - INFO [uvicorn.access] (MainThread) 127.0.0.1:34856 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-04-30 16:16:39,521 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_24) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: True,  flows[0, 7]:
 [{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 15, 'dl_
vlan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table
_id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port'
: 15, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tab
le', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match':
 {'in_port': 15, 'dl_vlan': 2222}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'},
 {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173
855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'act
ions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 121
73855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', '
actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 17}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 
12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 18, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 's
end_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12173855076158827076, 
'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 18, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_typ
e': 'pop_vlan'}, {'action_type': 'output', 'port': 15}]}]}]
2024-04-30 16:16:39,526 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_5) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: True,  flows[0, 7]: 
[{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 22, 'dl_v
lan': 2222, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_table', 'table_
id': 2}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port':
 22, 'dl_vlan': 2222, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'push_int'}]}, {'instruction_type': 'goto_tabl
e', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': 
{'in_port': 22, 'dl_vlan': 2222}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, 
{'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 5}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 121738
55076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 5, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'acti
ons': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 1217
3855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 5, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'a
ctions': [{'action_type': 'add_int_metadata'}, {'action_type': 'output', 'port': 25}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 1
2173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'se
nd_report'}]}, {'instruction_type': 'goto_table', 'table_id': 2}]}, {'table_id': 2, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20000, 'cookie': 12173855076158827076, '
idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 26, 'dl_vlan': 1}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'pop_int'}, {'action_type
': 'pop_vlan'}, {'action_type': 'output', 'port': 22}]}]}]
2024-04-30 16:16:39,536 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_26) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:02, command: add, force: True,  flows[0, 4]:
 [{'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 2, 'dl_v
lan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 
1}, {'action_type': 'output', 'port': 1}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'har
d_timeout': 0, 'match': {'in_port': 2, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instructions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metada
ta'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 1}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_group': 'evpl', 'priority': 20100, 'cookie': 
12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 1, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 6}, 'instructions': [{'instruction_type': 'apply_actions',
 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}, {'table_id': 0, 'owner': 'telemetry_int', 'table_g
roup': 'evpl', 'priority': 20100, 'cookie': 12173855076158827076, 'idle_timeout': 0, 'hard_timeout': 0, 'match': {'in_port': 1, 'dl_vlan': 1, 'dl_type': 2048, 'nw_proto': 17}, 'instruct
ions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}]
2024-04-30 16:16:39,587 - INFO [uvicorn.access] (MainThread) 127.0.0.1:34864 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
kytos $> 

```

Also confirmed with sdntrace_cp:

```
❯ echo '{ "trace": { "switch": { "dpid": "00:00:00:00:00:00:00:01", "in_port": 15}, "eth": {"dl_type": 2048, "dl_vlan": 2222}, "ip": { "nw_proto": 6 } } }' | http PUT http://127.0.0.1:81
81/api/amlight/sdntrace_cp/v1/trace
HTTP/1.1 200 OK
content-length: 479
content-type: application/json
date: Tue, 30 Apr 2024 19:16:51 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 15,
            "time": "2024-04-30 16:16:51.714447",
            "type": "starting",
            "vlan": 2222
        },
        {
            "dpid": "00:00:00:00:00:00:00:02",
            "port": 2,
            "time": "2024-04-30 16:16:51.714485",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 5,
            "time": "2024-04-30 16:16:51.714496",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "out": {
                "port": 22,
                "vlan": 2222
            },
            "port": 26,
            "time": "2024-04-30 16:16:51.714506",
            "type": "last",
            "vlan": 1
        }
    ]
}

```

### End-to-End Tests

N/A yet.