### PR TITLE
fix: validate has int when redeploying

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Changed
 =======
 - Only raise ``FlowsNotFound`` when an EVC is active and flows aren't found. Update status and status_reason accordingly too when installing flows.
 
+Fixed
+=====
+- Only redeploy if INT has been enabled before
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -232,7 +232,7 @@ class Main(KytosNApp):
             await self.int_manager.redeploy_int(evcs)
         except (EVCNotFound, FlowsNotFound, ProxyPortNotFound) as exc:
             raise HTTPException(404, detail=str(exc))
-        except ProxyPortSameSourceIntraEVC as exc:
+        except (EVCHasNoINT, ProxyPortSameSourceIntraEVC) as exc:
             raise HTTPException(409, detail=str(exc))
         except RetryError as exc:
             exc_error = str(exc.last_attempt.exception())

--- a/managers/int.py
+++ b/managers/int.py
@@ -355,6 +355,7 @@ class INTManager:
 
         evcs is a dict of prefetched EVCs from mef_eline based on evc_ids.
         """
+        self._validate_has_int(evcs)
         evcs = self._validate_map_enable_evcs(evcs, force=True)
         log.info(f"Redeploying INT on EVC ids: {list(evcs.keys())}, force: True")
 
@@ -529,6 +530,11 @@ class INTManager:
 
             self._validate_intra_evc_different_proxy_ports(evc)
         return evcs
+
+    def _validate_has_int(self, evcs: dict[str, dict]):
+        for evc_id, evc in evcs.items():
+            if not utils.has_int_enabled(evc):
+                raise EVCHasNoINT(evc_id)
 
     def _add_pps_evc_ids(self, evcs: dict[str, dict]):
         """Add proxy ports evc_ids.


### PR DESCRIPTION
Closes #94 

This is on top of PR #95 

### Summary

See updated changelog file 

### Local Tests

- Tried to redeploy an EVC without INT, resulted in 409, and then enabled and redeployed:

```
{
    "description": "EVC ad4e4c63cf154b INT isn't enabled",
    "code": 409
}
```

```
2024-05-01 16:54:00,173 - INFO [uvicorn.access] (MainThread) 127.0.0.1:57882 - "PATCH /api/kytos/telemetry_int/v1/evc/redeploy HTTP/1.1" 409
2024-05-01 16:54:21,556 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58798 - "GET /api/kytos/mef_eline/v2/evc/ad4e4c63cf154b HTTP/1.1" 200
2024-05-01 16:54:21,563 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58802 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-05-01 16:54:21,564 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Enabling INT on EVC ids: ['ad4e4c63cf154b'], force: True
2024-05-01 16:54:21,571 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58808 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-05-01 16:54:21,588 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58814 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2024-05-01 16:54:21,589 - INFO [uvicorn.access] (MainThread) 127.0.0.1:58790 - "POST /api/kytos/telemetry_int/v1/evc/enable HTTP/1.1" 201
2024-05-01 16:54:26,729 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53924 - "GET /api/kytos/mef_eline/v2/evc/ad4e4c63cf154b HTTP/1.1" 200
2024-05-01 16:54:26,730 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Redeploying INT on EVC ids: ['ad4e4c63cf154b'], force: True
2024-05-01 16:54:26,737 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53930 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-05-01 16:54:26,744 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53936 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-05-01 16:54:26,756 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53938 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2024-05-01 16:54:26,757 - INFO [uvicorn.access] (MainThread) 127.0.0.1:53908 - "PATCH /api/kytos/telemetry_int/v1/evc/redeploy HTTP/1.1" 201
```

### End-to-End Tests

N/A yet
