### PR TITLE
chore: refactored to use content id instead of content evc_id

### DIFF
--- a/main.py
+++ b/main.py
@@ -324,7 +324,7 @@ class Main(KytosNApp):
             and "telemetry" in content["metadata"]
             and content["metadata"]["telemetry"]["enabled"]
         ):
-            evc_id = content["evc_id"]
+            evc_id = content["id"]
             log.info(f"Handling mef_eline.deleted on EVC id: {evc_id}")
             await self.int_manager.disable_int({evc_id: content}, force=True)
 
@@ -332,8 +332,7 @@ class Main(KytosNApp):
     async def on_evc_deployed(self, event: KytosEvent) -> None:
         """On EVC deployed."""
         content = event.content
-        evc_id = content["evc_id"]
-        content["id"] = evc_id
+        evc_id = content["id"]
         evcs = {evc_id: content}
         try:
             if (
@@ -376,7 +375,7 @@ class Main(KytosNApp):
                     ),
                 }
             }
-            evc_id = content["evc_id"]
+            evc_id = content["id"]
             evcs = {evc_id: content}
             log.info(f"Handling mef_eline.undeployed on EVC id: {evc_id}")
             await self.int_manager.remove_int_flows(evcs, metadata, force=True)
@@ -391,8 +390,7 @@ class Main(KytosNApp):
             and "telemetry" in content["metadata"]
             and content["metadata"]["telemetry"]["enabled"]
         ):
-            evc_id = content["evc_id"]
-            content["id"] = evc_id
+            evc_id = content["id"]
             evcs = {evc_id: content}
             log.info(f"Handling {event.name}, EVC id: {evc_id}")
             try:
@@ -424,7 +422,7 @@ class Main(KytosNApp):
                     ),
                 }
             }
-            evc_id = content["evc_id"]
+            evc_id = content["id"]
             evcs = {evc_id: content}
             log.info(
                 f"Handling mef_eline.redeployed_link_down_no_path on EVC id: {evc_id}"
@@ -450,7 +448,7 @@ class Main(KytosNApp):
             and "telemetry" in content["metadata"]
             and content["metadata"]["telemetry"]["enabled"]
         ):
-            evc_id, active = content["evc_id"], content["active"]
+            evc_id, active = content["id"], content["active"]
             log.info(
                 f"Handling mef_eline.uni_active_updated active {active} "
                 f"on EVC id: {evc_id}"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -257,21 +257,21 @@ class TestMain:
 
     async def test_on_evc_deployed(self) -> None:
         """Test on_evc_deployed."""
-        content = {"metadata": {"telemetry_request": {}}, "evc_id": "some_id"}
+        content = {"metadata": {"telemetry_request": {}}, "id": "some_id"}
         self.napp.int_manager.redeploy_int = AsyncMock()
         self.napp.int_manager.enable_int = AsyncMock()
         await self.napp.on_evc_deployed(KytosEvent(content=content))
         assert self.napp.int_manager.enable_int.call_count == 1
         assert self.napp.int_manager.redeploy_int.call_count == 0
 
-        content = {"metadata": {"telemetry": {"enabled": True}}, "evc_id": "some_id"}
+        content = {"metadata": {"telemetry": {"enabled": True}}, "id": "some_id"}
         await self.napp.on_evc_deployed(KytosEvent(content=content))
         assert self.napp.int_manager.enable_int.call_count == 1
         assert self.napp.int_manager.redeploy_int.call_count == 1
 
     async def test_on_evc_deleted(self) -> None:
         """Test on_evc_deleted."""
-        content = {"metadata": {"telemetry": {"enabled": True}}, "evc_id": "some_id"}
+        content = {"metadata": {"telemetry": {"enabled": True}}, "id": "some_id"}
         self.napp.int_manager.disable_int = AsyncMock()
         await self.napp.on_evc_deleted(KytosEvent(content=content))
         assert self.napp.int_manager.disable_int.call_count == 1
@@ -285,7 +285,7 @@ class TestMain:
         )
         content = {
             "metadata": {"telemetry": {"enabled": True}},
-            "evc_id": "some_id",
+            "id": "some_id",
             "active": True,
         }
         await self.napp.on_uni_active_updated(KytosEvent(content=content))
@@ -304,7 +304,7 @@ class TestMain:
         content = {
             "enabled": False,
             "metadata": {"telemetry": {"enabled": False}},
-            "evc_id": "some_id",
+            "id": "some_id",
         }
         self.napp.int_manager.remove_int_flows = AsyncMock()
         await self.napp.on_evc_undeployed(KytosEvent(content=content))
@@ -319,7 +319,7 @@ class TestMain:
         content = {
             "enabled": True,
             "metadata": {"telemetry": {"enabled": False}},
-            "evc_id": "some_id",
+            "id": "some_id",
         }
         self.napp.int_manager.redeploy_int = AsyncMock()
         await self.napp.on_evc_redeployed_link(KytosEvent(content=content))
@@ -334,7 +334,7 @@ class TestMain:
         content = {
             "enabled": True,
             "metadata": {"telemetry": {"enabled": False}},
-            "evc_id": "some_id",
+            "id": "some_id",
         }
         self.napp.int_manager.remove_int_flows = AsyncMock()
         await self.napp.on_evc_error_redeployed_link_down(KytosEvent(content=content))


### PR DESCRIPTION
Closes #98 

### Summary

chore: refactored to use content id instead of content evc_id; internal refactoring no need to update changelog here on this NApp side.

### Local Tests

Exercised some of the events with telemetry_int:

```

kytos $> 2024-05-16 13:49:27,329 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) Removing EVC(df66e1705b1849, epl)
2024-05-16 13:49:27,332 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:03, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12312673024692918345, 'cookie_mask': 18446744073709551615}]
2024-05-16 13:49:27,338 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41726 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A03 HTTP/1.1" 202
2024-05-16 13:49:27,344 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:01, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12312673024692918345, 'cookie_mask': 18446744073709551615}]
2024-05-16 13:49:27,349 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41736 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01 HTTP/1.1" 202
2024-05-16 13:49:27,358 - INFO [kytos.napps.kytos/flow_manager] (AnyIO worker thread) Send FlowMod from request dpid: 00:00:00:00:00:00:00:02, command: delete, force: True,  flows[0, 1
]: [{'cookie': 12312673024692918345, 'cookie_mask': 18446744073709551615}]
2024-05-16 13:49:27,362 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41744 - "POST /api/kytos/flow_manager/v2/delete/00%3A00%3A00%3A00%3A00%3A00%3A00%3A02 HTTP/1.1" 202
2024-05-16 13:49:27,366 - INFO [kytos.napps.kytos/mef_eline] (AnyIO worker thread) EVC removed. EVC(df66e1705b1849, epl)
2024-05-16 13:49:27,369 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41710 - "DELETE /api/kytos/mef_eline/v2/evc/df66e1705b1849 HTTP/1.1" 200
2024-05-16 13:49:27,371 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling mef_eline.deleted on EVC id: df66e1705b1849
2024-05-16 13:49:27,371 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Disabling INT on EVC ids: ['df66e1705b1849'], force: True
2024-05-16 13:49:27,379 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41760 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200
2024-05-16 13:49:27,391 - INFO [uvicorn.access] (MainThread) 127.0.0.1:41770 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 404
kytos $> 
```

### End-to-End Tests

N/A yet
