### PR TITLE
feat: subscribe and handle `kytos/mef_eline.(failover_link_down|failover_old_path|failover_deployed)`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 - Handled ``kytos/mef_eline.error_redeploy_link_down`` event.
 - Handled ``kytos/mef_eline.uni_active_updated`` event.
 - Handled ``kytos/mef_eline.deployed`` event.
+- Handled ``kytos/mef_eline.(failover_link_down|failover_old_path|failover_deployed)`` events.
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -431,18 +431,21 @@ class Main(KytosNApp):
 
     @alisten_to("kytos/mef_eline.failover_link_down")
     async def on_failover_link_down(self, event: KytosEvent):
+        """Handle kytos/mef_eline.failover_link_down."""
         await self.int_manager.handle_failover_flows(
             event.content, event_name="failover_link_down"
         )
 
     @alisten_to("kytos/mef_eline.failover_old_path")
     async def on_failover_old_path(self, event: KytosEvent):
+        """Handle kytos/mef_eline.failover_old_path."""
         await self.int_manager.handle_failover_flows(
             event.content, event_name="failover_old_path"
         )
 
     @alisten_to("kytos/mef_eline.failover_deployed")
     async def on_failover_deployed(self, event: KytosEvent):
+        """Handle kytos/mef_eline.failover_deployed."""
         await self.int_manager.handle_failover_flows(
             event.content, event_name="failover_deployed"
         )

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ class Main(KytosNApp):
                     for evc_id in evcs
                 ]
             )
-            await self.int_manager._remove_int_flows(stored_flows)
+            await self.int_manager._remove_int_flows_by_cookies(stored_flows)
             await self.int_manager.enable_int(evcs, force)
         except (EVCNotFound, FlowsNotFound, ProxyPortNotFound) as exc:
             raise HTTPException(404, detail=str(exc))
@@ -431,8 +431,21 @@ class Main(KytosNApp):
 
     @alisten_to("kytos/mef_eline.failover_link_down")
     async def on_failover_link_down(self, event: KytosEvent):
-        log.info(f"Handling ev {event}; {event.content}")
-        await self.int_manager.handle_failover_link_down(event.content)
+        await self.int_manager.handle_failover_flows(
+            event.content, event_name="failover_link_down"
+        )
+
+    @alisten_to("kytos/mef_eline.failover_old_path")
+    async def on_failover_old_path(self, event: KytosEvent):
+        await self.int_manager.handle_failover_flows(
+            event.content, event_name="failover_old_path"
+        )
+
+    @alisten_to("kytos/mef_eline.failover_deployed")
+    async def on_failover_deployed(self, event: KytosEvent):
+        await self.int_manager.handle_failover_flows(
+            event.content, event_name="failover_deployed"
+        )
 
     @alisten_to("kytos/topology.link_down")
     async def on_link_down(self, event):

--- a/main.py
+++ b/main.py
@@ -429,6 +429,11 @@ class Main(KytosNApp):
             )
             await self.int_manager.remove_int_flows(evcs, metadata, force=True)
 
+    @alisten_to("kytos/mef_eline.failover_link_down")
+    async def on_failover_link_down(self, event: KytosEvent):
+        log.info(f"Handling ev {event}; {event.content}")
+        await self.int_manager.handle_failover_link_down(event.content)
+
     @alisten_to("kytos/topology.link_down")
     async def on_link_down(self, event):
         """Handle topology.link_down."""

--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -7,7 +7,6 @@ import itertools
 from typing import Literal
 
 from napps.kytos.telemetry_int import utils
-from napps.kytos.telemetry_int.exceptions import FlowsNotFound
 from napps.kytos.telemetry_int import settings
 
 
@@ -73,9 +72,7 @@ class FlowBuilder:
                 break
 
         if not new_int_flow_tbl_0_tcp:
-            if not evc["active"]:
-                return []
-            raise FlowsNotFound(evc["id"])
+            return []
 
         utils.set_instructions_from_actions(new_int_flow_tbl_0_tcp)
         utils.set_new_cookie(new_int_flow_tbl_0_tcp)
@@ -224,9 +221,7 @@ class FlowBuilder:
             new_int_flow_tbl_0_tcp = copy.deepcopy(flow)
 
             if not new_int_flow_tbl_0_tcp:
-                if not evc["active"]:
-                    return []
-                raise FlowsNotFound(evc["id"])
+                continue
 
             utils.set_new_cookie(new_int_flow_tbl_0_tcp)
             utils.set_owner(new_int_flow_tbl_0_tcp)

--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -41,6 +41,71 @@ class FlowBuilder:
                 flows_per_cookie[cookie].append(flow)
         return flows_per_cookie
 
+    def build_failover_old_flows(
+        self, evcs: dict[str, list[dict]], old_flows: dict[int, list[dict]]
+    ) -> dict[int, list[dict]]:
+        """Build (old path) failover related to remove flows.
+
+        If sink NNIs svlan are different, it'll regenerate the rest of sink loop flows.
+        Otherwise, it'll just remove the same received flows except with int cookie
+        value the deletion uses flow mod OFPFC_DELETE, so no need to include the
+        additional INT keys in the match like nw_proto for deletion.
+        """
+
+        removed_flows = defaultdict(list)
+        for evc_id, evc in evcs.items():
+            dpid_a, dpid_z = evc["uni_a"]["switch"], evc["uni_z"]["switch"]
+
+            cookie = utils.get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
+            int_cookie = settings.INT_COOKIE_PREFIX << 56 | (cookie & 0xFFFFFFFFFFFFFF)
+            cur_sink_a_svlan, cur_sink_z_svlan = None, None
+            sink_a_flows: list[dict] = []
+            sink_z_flows: list[dict] = []
+
+            for link in evc["current_path"]:
+                if cur_sink_a_svlan is None and (
+                    svlan := utils.get_svlan_dpid_link(link, dpid_a)
+                ):
+                    cur_sink_a_svlan = svlan
+                if cur_sink_z_svlan is None and (
+                    svlan := utils.get_svlan_dpid_link(link, dpid_z)
+                ):
+                    cur_sink_z_svlan = svlan
+                if cur_sink_a_svlan is not None and cur_sink_z_svlan is not None:
+                    break
+
+            for flow in old_flows[cookie]:
+                if not sink_a_flows and flow["switch"] == dpid_a:
+                    if (
+                        flow["flow"]["match"]["dl_vlan"] != cur_sink_a_svlan
+                        and cur_sink_a_svlan
+                    ):
+                        sink_a_flows = self._build_int_sink_flows(
+                            "uni_a", evc, old_flows
+                        )
+                    else:
+                        flow["flow"]["cookie"] = int_cookie
+                        sink_a_flows = [flow]
+                elif not sink_z_flows and flow["switch"] == dpid_z:
+                    if (
+                        flow["flow"]["match"]["dl_vlan"] != cur_sink_z_svlan
+                        and cur_sink_z_svlan
+                    ):
+                        sink_z_flows = self._build_int_sink_flows(
+                            "uni_z", evc, old_flows
+                        )
+                    else:
+                        flow["flow"]["cookie"] = int_cookie
+                        sink_z_flows = [flow]
+                if sink_a_flows and sink_z_flows:
+                    break
+
+            hop_flows = self._build_int_hop_flows(evc, old_flows)
+            removed_flows[cookie] = list(
+                itertools.chain(sink_a_flows, hop_flows, sink_z_flows)
+            )
+        return removed_flows
+
     def _build_int_source_flows(
         self,
         uni_src_key: Literal["uni_a", "uni_z"],

--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -42,7 +42,7 @@ class FlowBuilder:
         return flows_per_cookie
 
     def build_failover_old_flows(
-        self, evcs: dict[str, list[dict]], old_flows: dict[int, list[dict]]
+        self, evcs: dict[str, dict], old_flows: dict[int, list[dict]]
     ) -> dict[int, list[dict]]:
         """Build (old path) failover related to remove flows.
 

--- a/managers/int.py
+++ b/managers/int.py
@@ -778,11 +778,14 @@ class INTManager:
                 batch_size = len(flows)
 
             for i in range(0, len(flows), batch_size):
+                flows = flows[i : i + batch_size]
+                if not flows:
+                    continue
+
                 if i > 0:
                     await asyncio.sleep(settings.BATCH_INTERVAL)
-                flows = flows[i : i + batch_size]
                 event = KytosEvent(
-                    f"kytos.flow_manager.flows.{cmd}",
+                    f"kytos.flow_manager.flows.single.{cmd}",
                     content={
                         "dpid": dpid,
                         "force": True,

--- a/managers/int.py
+++ b/managers/int.py
@@ -708,7 +708,7 @@ class INTManager:
 
     async def _remove_int_flows_by_cookies(
         self, stored_flows: dict[int, list[dict]]
-    ) -> None:
+    ) -> dict[str, list[dict]]:
         """Delete int flows given a prefiltered stored_flows by cookies.
         You should use this type of removal when you need to remove all
         flows associated with a cookie, if you need to include all keys in the match
@@ -734,8 +734,11 @@ class INTManager:
                     }
                 )
         await self._send_flows(switch_flows, "delete")
+        return switch_flows
 
-    async def _remove_int_flows(self, stored_flows: dict[int, list[dict]]) -> None:
+    async def _remove_int_flows(
+        self, stored_flows: dict[int, list[dict]]
+    ) -> dict[str, list[dict]]:
         """Delete int flows given a prefiltered stored_flows. This method is meant
         to be used when you need to match all the flow match keys, so, typically when
         you're removing just a subset of INT flows.
@@ -748,14 +751,18 @@ class INTManager:
             for flow in flows:
                 switch_flows[flow["switch"]].append(flow["flow"])
         await self._send_flows(switch_flows, "delete")
+        return switch_flows
 
-    async def _install_int_flows(self, stored_flows: dict[int, list[dict]]) -> None:
+    async def _install_int_flows(
+        self, stored_flows: dict[int, list[dict]]
+    ) -> dict[str, list[dict]]:
         """Install INT flow mods."""
         switch_flows = defaultdict(list)
         for flows in stored_flows.values():
             for flow in flows:
                 switch_flows[flow["switch"]].append(flow["flow"])
         await self._send_flows(switch_flows, "install")
+        return switch_flows
 
     async def _send_flows(
         self, switch_flows: dict[str, list[dict]], cmd: Literal["install", "delete"]

--- a/managers/int.py
+++ b/managers/int.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 from collections import defaultdict
 from datetime import datetime
+from typing import Literal
 
 from pyof.v0x04.controller2switch.table_mod import Table
 
@@ -320,7 +321,7 @@ class INTManager:
             [utils.get_cookie(evc_id, settings.INT_COOKIE_PREFIX) for evc_id in evcs]
         )
         await asyncio.gather(
-            self._remove_int_flows(stored_flows),
+            self._remove_int_flows_by_cookies(stored_flows),
             api.add_evcs_metadata(evcs, metadata, force),
         )
 
@@ -362,7 +363,7 @@ class INTManager:
         stored_flows = await api.get_stored_flows(
             [utils.get_cookie(evc_id, settings.INT_COOKIE_PREFIX) for evc_id in evcs]
         )
-        await self._remove_int_flows(stored_flows)
+        await self._remove_int_flows_by_cookies(stored_flows)
         metadata = {
             "telemetry": {
                 "enabled": True,
@@ -386,16 +387,19 @@ class INTManager:
                 ]
             ),
         )
+        self._validate_evcs_stored_flows(evcs, stored_flows)
 
         active_evcs, inactive_evcs, pp_down_evcs = {}, {}, {}
         for evc_id, evc in evcs.items():
             if not evc["active"]:
                 inactive_evcs[evc_id] = evc
                 continue
-            if any((
-                evc["uni_a"]["proxy_port"].status != EntityStatus.UP,
-                evc["uni_z"]["proxy_port"].status != EntityStatus.UP,
-            )):
+            if any(
+                (
+                    evc["uni_a"]["proxy_port"].status != EntityStatus.UP,
+                    evc["uni_z"]["proxy_port"].status != EntityStatus.UP,
+                )
+            ):
                 pp_down_evcs[evc_id] = evc
                 continue
             active_evcs[evc_id] = evc
@@ -460,6 +464,16 @@ class INTManager:
             if not utils.has_int_enabled(evc) and not force:
                 raise EVCHasNoINT(evc_id)
 
+    def _validate_evcs_stored_flows(
+        self, evcs: dict[str, dict], stored_flows: dict[int, list[dict]]
+    ) -> None:
+        """Validate that each active EVC has corresponding flows."""
+        for evc_id, evc in evcs.items():
+            if evc["active"] and not stored_flows.get(
+                utils.get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
+            ):
+                raise FlowsNotFound(evc_id)
+
     def _validate_intra_evc_different_proxy_ports(self, evc: dict) -> None:
         """Validate that an intra EVC is using different proxy ports.
 
@@ -485,14 +499,23 @@ class INTManager:
             evc["id"], "intra EVC UNIs must use different proxy ports"
         )
 
-    async def handle_failover_link_down(self, evcs_content: dict[str, dict]) -> None:
-        """Handle failover link down.
+    async def handle_failover_flows(
+        self, evcs_content: dict[str, dict], event_name: str
+    ) -> None:
+        """Handle failover flows. This method will generate the subset
+        of INT flows. EVCs with 'flows' key will be installed, and
+        'old_flows' will be removed.
 
-        When handling this event if a given proxy port has an unexpected
-        state INT will be removed falling back to mef_eline flows.
+        If a given proxy port has an unexpected state INT will be
+        removed falling back to mef_eline flows.
         """
-        evcs, to_remove = {}, {}
+        to_install, to_remove, to_remove_with_err = {}, {}, {}
         new_flows: dict[int, list[dict]] = defaultdict(list)
+        old_flows: dict[int, list[dict]] = defaultdict(list)
+
+        old_flows_key = "removed_flows"
+        new_flows_key = "flows"
+
         for evc_id, evc in evcs_content.items():
             if not utils.has_int_enabled(evc):
                 continue
@@ -504,22 +527,39 @@ class INTManager:
                 evc["id"] = evc_id
                 evc["uni_a"], evc["uni_z"] = uni_a, uni_z
             except ProxyPortError as e:
-                log.warning(f"Unexpected proxy port state: {str(e)}."
-                            f"INT will be removed on evc id {evc_id}")
-                to_remove[evc_id] = evc
+                log.error(
+                    f"Unexpected proxy port state: {str(e)}."
+                    f"INT will be removed on evc id {evc_id}"
+                )
+                to_remove_with_err[evc_id] = evc
                 continue
 
-            for dpid, flows in evc["flows"].items():
+            for dpid, flows in evc.get(new_flows_key, {}).items():
                 for flow in flows:
                     new_flows[flow["cookie"]].append({"flow": flow, "switch": dpid})
 
-            evc.pop("flows")
-            evcs[evc_id] = evc
+            for dpid, flows in evc.get(old_flows_key, {}).items():
+                for flow in flows:
+                    new_flows[flow["cookie"]].append({"flow": flow, "switch": dpid})
 
-        await self._install_int_flows(
-            self.flow_builder.build_int_flows(evcs, new_flows)
-        )
+            if evc.get(new_flows_key):
+                to_install[evc_id] = evc
+                evc.pop(new_flows_key)
+            if evc.get(old_flows_key):
+                to_remove[evc_id] = evc
+                evc.pop(old_flows_key, None)
+
         if to_remove:
+            log.info(
+                f"Handling {event_name} flows remove on EVC ids: {to_remove.keys()}"
+            )
+            built = self._build_failover_to_remove_flows(to_remove, old_flows)
+            await self._remove_int_flows(built)
+        if to_remove_with_err:
+            log.error(
+                f"Handling {event_name} proxy_port_error falling back "
+                f"to mef_eline, EVC ids: {list(to_remove_with_err.keys())}"
+            )
             metadata = {
                 "telemetry": {
                     "enabled": True,
@@ -530,7 +570,45 @@ class INTManager:
                     ),
                 }
             }
-            await self.remove_int_flows(evcs, metadata, force=True)
+            await self.remove_int_flows(to_remove_with_err, metadata, force=True)
+        if to_install:
+            log.info(
+                f"Handling {event_name} flows install on EVC ids: {to_install.keys()}"
+            )
+            await self._install_int_flows(
+                self.flow_builder.build_int_flows(to_install, new_flows)
+            )
+
+    def _build_failover_to_remove_flows(
+        self, evcs: dict[str, list[dict]], old_flows: dict[int, list[dict]]
+    ) -> dict[int, list[dict]]:
+        """Build (old path) failover related to remove flows.
+
+        If sink nnis svlan are different it'll regenerate the rest of sink loop flows,
+        otherwise, it'll just remove the same received flows except with int cookie
+        value the deletion uses flow mod OFPFC_DELETE, so no need to include the
+        additional INT keys in the match like nw_proto for deletion.
+        """
+        # TODO implement diff checking per EVC...
+        diff_svlans = True
+        if diff_svlans:
+            for cookie, flows in old_flows.items():
+                for flow in flows:
+                    flow["flow"]["priority"] = 2100
+                    flow["flow"]["table_group"] = (
+                        "evpl" if "dl_vlan" in flow.get("match", {}) else "epl"
+                    )
+            return self.flow_builder.build_int_flows(evcs, old_flows)
+
+        cookie_mask = int(0xFFFFFFFFFFFFFFFF)
+        for cookie, flows in old_flows.items():
+            int_cookie = hex(
+                settings.INT_COOKIE_PREFIX << 56 | (cookie & 0xFFFFFFFFFFFFFF)
+            )
+            for flow in flows:
+                flow["flow"]["cookie"] = int_cookie
+                flow["flow"]["cookie_mask"] = cookie_mask
+        return old_flows
 
     def _validate_map_enable_evcs(
         self,
@@ -652,73 +730,76 @@ class INTManager:
                 results[evc_id].append("missing_some_int_flows")
         return results
 
-    async def _remove_int_flows(self, stored_flows: dict[int, list[dict]]) -> None:
-        """Delete int flows given a prefiltered stored_flows.
+    async def _remove_int_flows_by_cookies(
+        self, stored_flows: dict[int, list[dict]]
+    ) -> None:
+        """Delete int flows given a prefiltered stored_flows by cookies.
+        You should use this type of removal when you need to remove all
+        flows associated with a cookie, if you need to include all keys in the match
+        to remove only a subset use `_remove_int_flows(stored_flows)` method instead.
 
         Removal is driven by the stored flows instead of EVC ids and dpids to also
         be able to handle the force mode when an EVC no longer exists. It also follows
         the same pattern that mef_eline currently uses.
-
-        The flows will be batched per dpid based on settings.BATCH_SIZE and will wait
-        for settings.BATCH_INTERVAL per batch iteration.
-
         """
-        switch_flows = defaultdict(set)
+        switch_flows_cookies = defaultdict(set)
         for flows in stored_flows.values():
             for flow in flows:
-                switch_flows[flow["switch"]].add(flow["flow"]["cookie"])
+                switch_flows_cookies[flow["switch"]].add(flow["flow"]["cookie"])
 
-        for dpid, cookies in switch_flows.items():
-            cookie_vals = list(cookies)
-            batch_size = settings.BATCH_SIZE
-            if batch_size <= 0:
-                batch_size = len(cookie_vals)
-
-            for i in range(0, len(cookie_vals), batch_size):
-                if i > 0:
-                    await asyncio.sleep(settings.BATCH_INTERVAL)
-                flows = [
+        switch_flows = defaultdict(list)
+        for dpid, cookies in switch_flows_cookies.items():
+            for cookie in cookies:
+                switch_flows[dpid].append(
                     {
                         "cookie": cookie,
                         "cookie_mask": int(0xFFFFFFFFFFFFFFFF),
                         "table_id": Table.OFPTT_ALL.value,
                     }
-                    for cookie in cookie_vals[i : i + batch_size]
-                ]
-                event = KytosEvent(
-                    "kytos.flow_manager.flows.delete",
-                    content={
-                        "dpid": dpid,
-                        "force": True,
-                        "flow_dict": {"flows": flows},
-                    },
                 )
-                await self.controller.buffers.app.aput(event)
+        await self._send_flows(switch_flows, "delete")
 
-    async def _install_int_flows(self, stored_flows: dict[int, list[dict]]) -> None:
-        """Install INT flow mods.
+    async def _remove_int_flows(self, stored_flows: dict[int, list[dict]]) -> None:
+        """Delete int flows given a prefiltered stored_flows. This method is meant
+        to be used when you need to match all the flow match keys, so, typically when
+        you're removing just a subset of INT flows.
 
-        The flows will be batched per dpid based on settings.BATCH_SIZE and will wait
-        for settings.BATCH_INTERVAL per batch iteration.
-        """
-
+        Removal is driven by the stored flows instead of EVC ids and dpids to also
+        be able to handle the force mode when an EVC no longer exists. It also follows
+        the same pattern that mef_eline currently uses."""
         switch_flows = defaultdict(list)
         for flows in stored_flows.values():
             for flow in flows:
                 switch_flows[flow["switch"]].append(flow["flow"])
+        await self._send_flows(switch_flows, "delete")
 
+    async def _install_int_flows(self, stored_flows: dict[int, list[dict]]) -> None:
+        """Install INT flow mods."""
+        switch_flows = defaultdict(list)
+        for flows in stored_flows.values():
+            for flow in flows:
+                switch_flows[flow["switch"]].append(flow["flow"])
+        await self._send_flows(switch_flows, "install")
+
+    async def _send_flows(
+        self, switch_flows: dict[str, list[dict]], cmd: Literal["install", "delete"]
+    ):
+        """Send batched flows by dpid to flow_manager.
+
+        The flows will be batched per dpid based on settings.BATCH_SIZE and will wait
+        for settings.BATCH_INTERVAL per batch iteration.
+        """
         for dpid, flows in switch_flows.items():
-            flow_vals = list(flows)
             batch_size = settings.BATCH_SIZE
             if batch_size <= 0:
-                batch_size = len(flow_vals)
+                batch_size = len(flows)
 
-            for i in range(0, len(flow_vals), batch_size):
+            for i in range(0, len(flows), batch_size):
                 if i > 0:
                     await asyncio.sleep(settings.BATCH_INTERVAL)
-                flows = flow_vals[i : i + batch_size]
+                flows = flows[i : i + batch_size]
                 event = KytosEvent(
-                    "kytos.flow_manager.flows.install",
+                    f"kytos.flow_manager.flows.{cmd}",
                     content={
                         "dpid": dpid,
                         "force": True,

--- a/tests/unit/test_flow_builder_failover.py
+++ b/tests/unit/test_flow_builder_failover.py
@@ -1,3 +1,4 @@
+"""Test flowbuilder failover flows."""
 import json
 
 from unittest.mock import AsyncMock, MagicMock
@@ -390,7 +391,7 @@ async def test_handle_failover_old_path_same_svlan() -> None:
             },
             "current_path": [
                 {
-                    "id": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
+                    "id": "78282c4d5",
                     "endpoint_a": {
                         "id": "00: 00:00:00:00:00:00:01:3",
                         "name": "s1-eth3",
@@ -407,7 +408,7 @@ async def test_handle_failover_old_path_same_svlan() -> None:
                         "enabled": True,
                         "status": "UP",
                         "status_reason": [],
-                        "link": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
+                        "link": "78282c4d5",
                     },
                     "endpoint_b": {
                         "id": "00:00:00:00:00:00:00:02:2",
@@ -425,7 +426,7 @@ async def test_handle_failover_old_path_same_svlan() -> None:
                         "enabled": True,
                         "status": "UP",
                         "status_reason": [],
-                        "link": "78282c4d5b579265f04ebadc4405ca1b4 9628eb1d684bb45e5d0607fa8b713d0",
+                        "link": "78282c4d5",
                     },
                     "metadata": {"s_vlan": {"tag_type": "vlan", "value": 1}},
                     "active": True,
@@ -434,7 +435,7 @@ async def test_handle_failover_old_path_same_svlan() -> None:
                     "status_reason": [],
                 },
                 {
-                    "id": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                    "id": "4d42dc085",
                     "endpoint_a": {
                         "id": "00:00:00:00:00:00:00:02:3",
                         "name": "s2-eth3",
@@ -451,7 +452,7 @@ async def test_handle_failover_old_path_same_svlan() -> None:
                         "enabled": True,
                         "status": "UP",
                         "status_reason ": [],
-                        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                        "link": "4d42dc085",
                     },
                     "endpoint_b": {
                         "id": "00:00:00:00:00:00:00:03:2",
@@ -469,7 +470,7 @@ async def test_handle_failover_old_path_same_svlan() -> None:
                         "enabled": True,
                         "status": "UP",
                         "status_reason": [],
-                        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                        "link": "4d42dc085",
                     },
                     "metadata": {"s_vlan": {"tag_type": "vlan", "value": 1}},
                     "active": True,
@@ -541,6 +542,7 @@ async def test_handle_failover_old_path_same_svlan() -> None:
     assert json.dumps(int_manager._remove_int_flows.call_args[0][0]) == serd
 
 
+# pylint: disable=too-many-statements
 async def test_handle_failover_old_path_diff_svlan() -> None:
     """Test handle failover_old_path_diff_svlan.
 
@@ -642,7 +644,7 @@ async def test_handle_failover_old_path_diff_svlan() -> None:
             },
             "current_path": [
                 {
-                    "id": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
+                    "id": "78282c4d5",
                     "endpoint_a": {
                         "id": "00:00:00:00:00:00:00:01:3",
                         "name": "s1-eth3",
@@ -659,7 +661,7 @@ async def test_handle_failover_old_path_diff_svlan() -> None:
                         "enabled": True,
                         "status": "UP",
                         "status_reason": [],
-                        "link": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
+                        "link": "78282c4d5",
                     },
                     "endpoint_b": {
                         "id": "00:00:00:00:00:00:00:02:2",
@@ -677,7 +679,7 @@ async def test_handle_failover_old_path_diff_svlan() -> None:
                         "enabled": True,
                         "status": "UP",
                         "status_reason": [],
-                        "link": "78282c4d5b579265f04ebadc4405ca1b4 9628eb1d684bb45e5d0607fa8b713d0",
+                        "link": "78282c4d5",
                     },
                     "metadata": {"s_vlan": {"tag_type": "vlan", "value": 1}},
                     "active": True,
@@ -686,7 +688,7 @@ async def test_handle_failover_old_path_diff_svlan() -> None:
                     "status_reason": [],
                 },
                 {
-                    "id": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                    "id": "4d42dc085",
                     "endpoint_a": {
                         "id": "00:00:00:00:00:00:00:02:3",
                         "name": "s2-eth3",
@@ -703,7 +705,7 @@ async def test_handle_failover_old_path_diff_svlan() -> None:
                         "enabled": True,
                         "status": "UP",
                         "status_reason ": [],
-                        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                        "link": "4d42dc085",
                     },
                     "endpoint_b": {
                         "id": "00:00:00:00:00:00:00:03:2",
@@ -721,7 +723,7 @@ async def test_handle_failover_old_path_diff_svlan() -> None:
                         "enabled": True,
                         "status": "UP",
                         "status_reason": [],
-                        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                        "link": "4d42dc085",
                     },
                     "metadata": {"s_vlan": {"tag_type": "vlan", "value": 1}},
                     "active": True,

--- a/tests/unit/test_flow_builder_failover.py
+++ b/tests/unit/test_flow_builder_failover.py
@@ -1,4 +1,5 @@
 """Test flowbuilder failover flows."""
+
 import json
 
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/unit/test_flow_builder_failover.py
+++ b/tests/unit/test_flow_builder_failover.py
@@ -1,0 +1,945 @@
+import json
+
+from unittest.mock import AsyncMock, MagicMock
+from napps.kytos.telemetry_int.managers.int import INTManager
+from napps.kytos.telemetry_int.proxy_port import ProxyPort
+from kytos.lib.helpers import get_controller_mock, get_switch_mock, get_interface_mock
+from kytos.core.common import EntityStatus
+
+
+async def test_handle_failover_link_down() -> None:
+    """Test handle failover_link_down.
+
+               +----+                                              +----+
+              5|    |6                                            5|    |6
+           +---+----v---+            +------------+           +----+----v---+
+        1  |            |            |            |           |             |1
+    -------+            |3         2 |            |3        2 |             +-------
+     vlan  |     s1     +------------+    s2      +-----------+    s3       | vlan
+     100   |            |            |            |           |             | 100
+           |            |            |            |           |             |
+           +------------+            +------------+           +-------------+
+                |4                                                   3|
+                |_____________________________________________________|
+    """
+
+    controller = get_controller_mock()
+    int_manager = INTManager(controller)
+    get_proxy_port_or_raise = MagicMock()
+    int_manager.get_proxy_port_or_raise = get_proxy_port_or_raise
+
+    dpid_a = "00:00:00:00:00:00:00:01"
+    mock_switch_a = get_switch_mock(dpid_a, 0x04)
+    mock_interface_a1 = get_interface_mock("s1-eth1", 1, mock_switch_a)
+    mock_interface_a1.id = f"{dpid_a}:{mock_interface_a1.port_number}"
+    mock_interface_a5 = get_interface_mock("s1-eth5", 5, mock_switch_a)
+    mock_interface_a1.metadata = {"proxy_port": mock_interface_a5.port_number}
+    mock_interface_a5.status = EntityStatus.UP
+    mock_interface_a6 = get_interface_mock("s1-eth6", 6, mock_switch_a)
+    mock_interface_a6.status = EntityStatus.UP
+    mock_interface_a5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_a5.port_number,
+                mock_interface_a6.port_number,
+            ]
+        }
+    }
+
+    dpid_z = "00:00:00:00:00:00:00:03"
+    mock_switch_z = get_switch_mock(dpid_z, 0x04)
+    mock_interface_z1 = get_interface_mock("s1-eth1", 1, mock_switch_z)
+    mock_interface_z1.status = EntityStatus.UP
+    mock_interface_z1.id = f"{dpid_z}:{mock_interface_z1.port_number}"
+    mock_interface_z5 = get_interface_mock("s1-eth5", 5, mock_switch_z)
+    mock_interface_z1.metadata = {"proxy_port": mock_interface_z5.port_number}
+    mock_interface_z5.status = EntityStatus.UP
+    mock_interface_z6 = get_interface_mock("s1-eth6", 6, mock_switch_z)
+    mock_interface_z6.status = EntityStatus.UP
+    mock_interface_z5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_z5.port_number,
+                mock_interface_z6.port_number,
+            ]
+        }
+    }
+
+    mock_switch_a.get_interface_by_port_no = lambda port_no: {
+        mock_interface_a5.port_number: mock_interface_a5,
+        mock_interface_a6.port_number: mock_interface_a6,
+    }[port_no]
+
+    mock_switch_z.get_interface_by_port_no = lambda port_no: {
+        mock_interface_z5.port_number: mock_interface_z5,
+        mock_interface_z6.port_number: mock_interface_z6,
+    }[port_no]
+
+    pp_a = ProxyPort(controller, source=mock_interface_a5)
+    assert pp_a.source == mock_interface_a5
+    assert pp_a.destination == mock_interface_a6
+    pp_z = ProxyPort(controller, source=mock_interface_z5)
+    assert pp_z.source == mock_interface_z5
+    assert pp_z.destination == mock_interface_z6
+
+    evcs_data = {
+        "ceaf53b16c3a40": {
+            "flows": {
+                "00:00:00:00:00:00:00:01": [
+                    {
+                        "match": {"in_port": 1, "dl_vlan": 100},
+                        "cookie": 12307967605643950656,
+                        "actions": [
+                            {"action_type": "push_vlan", "tag_type": "s"},
+                            {"action_type": "set_vlan", "vlan_id": 1},
+                            {"action_type": "output", "port": 3},
+                        ],
+                        "owner": "mef_eline",
+                        "table_group": "evpl",
+                        "table_id": 0,
+                        "priority": 20000,
+                    }
+                ],
+                "00:00:00:00:00:00:00:03": [
+                    {
+                        "match": {"in_port": 1, "dl_vlan": 100},
+                        "cookie": 12307967605643950656,
+                        "actions": [
+                            {"action_type": "push_vlan", "tag_type": "s"},
+                            {"action_type": "set_vlan", "vlan_id": 1},
+                            {"action_type": "output", "port": 2},
+                        ],
+                        "owner": "mef_eline",
+                        "table_group": "evpl",
+                        "table_id": 0,
+                        "priority": 20000,
+                    }
+                ],
+            },
+            "evc_id": "ceaf53b16c3a40",
+            "id": "ceaf53b16c3a40",
+            "name": "inter_evpl",
+            "metadata": {
+                "telemetry_request": {},
+                "telemetry": {
+                    "enabled": True,
+                    "status": "UP",
+                    "status_reason": [],
+                    "status_updated_at": "2024-06-11T16:56:29",
+                },
+            },
+            "active": True,
+            "enabled": True,
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {"tag_type": "vlan", "value": 100},
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:03:1",
+                "tag": {"tag_type": "vlan", "value": 100},
+            },
+        }
+    }
+
+    int_manager._send_flows = AsyncMock()
+    int_manager._install_int_flows = AsyncMock()
+    int_manager._remove_int_flows = AsyncMock()
+    int_manager.remove_int_flows = AsyncMock()
+    await int_manager.handle_failover_flows(evcs_data, "failover_link_down")
+    assert int_manager._install_int_flows.call_count == 1
+    assert int_manager._remove_int_flows.call_count == 0
+    assert int_manager.remove_int_flows.call_count == 0
+
+    expected_built_flows = {
+        "12307967605643950656": [
+            {
+                "flow": {
+                    "match": {
+                        "in_port": 1,
+                        "dl_vlan": 100,
+                        "dl_type": 2048,
+                        "nw_proto": 6,
+                    },
+                    "cookie": 12163852417568094784,
+                    "owner": "telemetry_int",
+                    "table_group": "evpl",
+                    "table_id": 0,
+                    "priority": 20100,
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "push_int"}],
+                        },
+                        {"instruction_type": "goto_table", "table_id": 2},
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:01",
+            },
+            {
+                "flow": {
+                    "match": {
+                        "in_port": 1,
+                        "dl_vlan": 100,
+                        "dl_type": 2048,
+                        "nw_proto": 17,
+                    },
+                    "cookie": 12163852417568094784,
+                    "owner": "telemetry_int",
+                    "table_group": "evpl",
+                    "table_id": 0,
+                    "priority": 20100,
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "push_int"}],
+                        },
+                        {"instruction_type": "goto_table", "table_id": 2},
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:01",
+            },
+            {
+                "flow": {
+                    "match": {"in_port": 1, "dl_vlan": 100},
+                    "cookie": 12163852417568094784,
+                    "owner": "telemetry_int",
+                    "table_group": "evpl",
+                    "table_id": 2,
+                    "priority": 20000,
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [
+                                {"action_type": "add_int_metadata"},
+                                {"action_type": "push_vlan", "tag_type": "s"},
+                                {"action_type": "set_vlan", "vlan_id": 1},
+                                {"action_type": "output", "port": 3},
+                            ],
+                        }
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:01",
+            },
+            {
+                "flow": {
+                    "match": {
+                        "in_port": 1,
+                        "dl_vlan": 100,
+                        "dl_type": 2048,
+                        "nw_proto": 6,
+                    },
+                    "cookie": 12163852417568094784,
+                    "owner": "telemetry_int",
+                    "table_group": "evpl",
+                    "table_id": 0,
+                    "priority": 20100,
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "push_int"}],
+                        },
+                        {"instruction_type": "goto_table", "table_id": 2},
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:03",
+            },
+            {
+                "flow": {
+                    "match": {
+                        "in_port": 1,
+                        "dl_vlan": 100,
+                        "dl_type": 2048,
+                        "nw_proto": 17,
+                    },
+                    "cookie": 12163852417568094784,
+                    "owner": "telemetry_int",
+                    "table_group": "evpl",
+                    "table_id": 0,
+                    "priority": 20100,
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "push_int"}],
+                        },
+                        {"instruction_type": "goto_table", "table_id": 2},
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:03",
+            },
+            {
+                "flow": {
+                    "match": {"in_port": 1, "dl_vlan": 100},
+                    "cookie": 12163852417568094784,
+                    "owner": "telemetry_int",
+                    "table_group": "evpl",
+                    "table_id": 2,
+                    "priority": 20000,
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [
+                                {"action_type": "add_int_metadata"},
+                                {"action_type": "push_vlan", "tag_type": "s"},
+                                {"action_type": "set_vlan", "vlan_id": 1},
+                                {"action_type": "output", "port": 2},
+                            ],
+                        }
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:03",
+            },
+        ]
+    }
+
+    serd = json.dumps(expected_built_flows)
+    assert json.dumps(int_manager._install_int_flows.call_args[0][0]) == serd
+
+
+async def test_handle_failover_old_path_same_svlan() -> None:
+    """Test handle failover_old_path_same_svlan.
+
+               +----+                                              +----+
+              5|    |6                                            5|    |6
+           +---+----v---+            +------------+           +----+----v---+
+        1  |            |            |            |           |             |1
+    -------+            |3         2 |            |3        2 |             +-------
+     vlan  |     s1     +------------+    s2      +-----------+    s3       | vlan
+     100   |            |            |            |           |             | 100
+           |            |            |            |           |             |
+           +------------+            +------------+           +-------------+
+                |4                                                   3|
+                |_____________________________________________________|
+    """
+
+    controller = get_controller_mock()
+    int_manager = INTManager(controller)
+    get_proxy_port_or_raise = MagicMock()
+    int_manager.get_proxy_port_or_raise = get_proxy_port_or_raise
+
+    dpid_a = "00:00:00:00:00:00:00:01"
+    mock_switch_a = get_switch_mock(dpid_a, 0x04)
+    mock_interface_a1 = get_interface_mock("s1-eth1", 1, mock_switch_a)
+    mock_interface_a1.id = f"{dpid_a}:{mock_interface_a1.port_number}"
+    mock_interface_a5 = get_interface_mock("s1-eth5", 5, mock_switch_a)
+    mock_interface_a1.metadata = {"proxy_port": mock_interface_a5.port_number}
+    mock_interface_a5.status = EntityStatus.UP
+    mock_interface_a6 = get_interface_mock("s1-eth6", 6, mock_switch_a)
+    mock_interface_a6.status = EntityStatus.UP
+    mock_interface_a5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_a5.port_number,
+                mock_interface_a6.port_number,
+            ]
+        }
+    }
+
+    dpid_z = "00:00:00:00:00:00:00:03"
+    mock_switch_z = get_switch_mock(dpid_z, 0x04)
+    mock_interface_z1 = get_interface_mock("s1-eth1", 1, mock_switch_z)
+    mock_interface_z1.status = EntityStatus.UP
+    mock_interface_z1.id = f"{dpid_z}:{mock_interface_z1.port_number}"
+    mock_interface_z5 = get_interface_mock("s1-eth5", 5, mock_switch_z)
+    mock_interface_z1.metadata = {"proxy_port": mock_interface_z5.port_number}
+    mock_interface_z5.status = EntityStatus.UP
+    mock_interface_z6 = get_interface_mock("s1-eth6", 6, mock_switch_z)
+    mock_interface_z6.status = EntityStatus.UP
+    mock_interface_z5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_z5.port_number,
+                mock_interface_z6.port_number,
+            ]
+        }
+    }
+
+    mock_switch_a.get_interface_by_port_no = lambda port_no: {
+        mock_interface_a5.port_number: mock_interface_a5,
+        mock_interface_a6.port_number: mock_interface_a6,
+    }[port_no]
+
+    mock_switch_z.get_interface_by_port_no = lambda port_no: {
+        mock_interface_z5.port_number: mock_interface_z5,
+        mock_interface_z6.port_number: mock_interface_z6,
+    }[port_no]
+
+    pp_a = ProxyPort(controller, source=mock_interface_a5)
+    assert pp_a.source == mock_interface_a5
+    assert pp_a.destination == mock_interface_a6
+    pp_z = ProxyPort(controller, source=mock_interface_z5)
+    assert pp_z.source == mock_interface_z5
+    assert pp_z.destination == mock_interface_z6
+
+    evcs_data = {
+        "ceaf53b16c3a40": {
+            "removed_flows": {
+                "00:00:00:00:00:00:00:01": [
+                    {
+                        "cookie": 12307967605643950656,
+                        "match": {"in_port": 4, "dl_vlan": 1},
+                        "cookie_mask": 18446744073709551615,
+                    }
+                ],
+                "00:00:00:00:00:00:00:03": [
+                    {
+                        "cookie": 12307967605643950656,
+                        "match": {"in_port": 3, "dl_vlan": 1},
+                        "cookie_mask": 18446744073709551615,
+                    }
+                ],
+            },
+            "current_path": [
+                {
+                    "id": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
+                    "endpoint_a": {
+                        "id": "00: 00:00:00:00:00:00:01:3",
+                        "name": "s1-eth3",
+                        "port_number": 3,
+                        "mac": "b2:ac:2b:ac:87:bb",
+                        "switch": "00:00:00:00:00:00:00:01",
+                        "type": "interface",
+                        "nni": True,
+                        "uni": False,
+                        "speed": 1250000000.0,
+                        "metadata": {},
+                        "lldp": True,
+                        "active": True,
+                        "enabled": True,
+                        "status": "UP",
+                        "status_reason": [],
+                        "link": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
+                    },
+                    "endpoint_b": {
+                        "id": "00:00:00:00:00:00:00:02:2",
+                        "name": "s2-eth2",
+                        "port_number": 2,
+                        "mac": "62:50:49:d7:79:8a",
+                        "switch": "00:00:00:00:00:00:00:02",
+                        "type": "interface",
+                        "nni": True,
+                        "uni": False,
+                        "speed": 1250000000.0,
+                        "metadata": {},
+                        "lldp": True,
+                        "active": True,
+                        "enabled": True,
+                        "status": "UP",
+                        "status_reason": [],
+                        "link": "78282c4d5b579265f04ebadc4405ca1b4 9628eb1d684bb45e5d0607fa8b713d0",
+                    },
+                    "metadata": {"s_vlan": {"tag_type": "vlan", "value": 1}},
+                    "active": True,
+                    "enabled": True,
+                    "status": "UP",
+                    "status_reason": [],
+                },
+                {
+                    "id": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                    "endpoint_a": {
+                        "id": "00:00:00:00:00:00:00:02:3",
+                        "name": "s2-eth3",
+                        "port_number": 3,
+                        "mac": "76:82:ef:6e:d2:9d",
+                        "switch": "00:00:00:00:00:00:00:02",
+                        "type": "interface",
+                        "nni": True,
+                        "uni": False,
+                        "speed": 1250000000.0,
+                        "metadata": {},
+                        "lldp": True,
+                        "active": True,
+                        "enabled": True,
+                        "status": "UP",
+                        "status_reason ": [],
+                        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                    },
+                    "endpoint_b": {
+                        "id": "00:00:00:00:00:00:00:03:2",
+                        "name": "s3-eth2",
+                        "port_number": 2,
+                        "mac": "6a:c1:51:b1:a9:8a",
+                        "switch": "00:00:00:00:00:00:00:03",
+                        "type": "interface",
+                        "nni": True,
+                        "uni": False,
+                        "speed": 1250000000.0,
+                        "metadata": {},
+                        "lldp": True,
+                        "active": True,
+                        "enabled": True,
+                        "status": "UP",
+                        "status_reason": [],
+                        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                    },
+                    "metadata": {"s_vlan": {"tag_type": "vlan", "value": 1}},
+                    "active": True,
+                    "enabled": True,
+                    "status": "UP",
+                    "status_reason": [],
+                },
+            ],
+            "evc_id": "ceaf53b16c3a40",
+            "id": "ceaf53b16c3a40",
+            "name": "inter_evpl",
+            "metadata": {
+                "telemetry_request": {},
+                "telemetry": {
+                    "enabled": True,
+                    "status": "UP",
+                    "status_reason": [],
+                    "status_updated_at": "2024-06-11T16:56:29",
+                },
+            },
+            "active": True,
+            "enabled": True,
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {"tag_type": "vlan", "value": 100},
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:03:1",
+                "tag": {"tag_type": "vlan", "value": 100},
+            },
+        }
+    }
+
+    get_proxy_port_or_raise.side_effect = [pp_a, pp_z]
+    int_manager._send_flows = AsyncMock()
+    int_manager._install_int_flows = AsyncMock()
+    int_manager._remove_int_flows = AsyncMock()
+    int_manager.remove_int_flows = AsyncMock()
+    await int_manager.handle_failover_flows(evcs_data, "failover_old_path")
+    assert int_manager._install_int_flows.call_count == 0
+    assert int_manager._remove_int_flows.call_count == 1
+    assert int_manager.remove_int_flows.call_count == 0
+
+    expected_built_flows = {
+        "12307967605643950656": [
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {"in_port": 4, "dl_vlan": 1},
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21000,
+                    "table_group": "evpl",
+                },
+                "switch": "00:00:00:00:00:00:00:01",
+            },
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {"in_port": 3, "dl_vlan": 1},
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21000,
+                    "table_group": "evpl",
+                },
+                "switch": "00:00:00:00:00:00:00:03",
+            },
+        ]
+    }
+    serd = json.dumps(expected_built_flows)
+    assert json.dumps(int_manager._remove_int_flows.call_args[0][0]) == serd
+
+
+async def test_handle_failover_old_path_diff_svlan() -> None:
+    """Test handle failover_old_path_diff_svlan.
+
+               +----+                                              +----+
+              5|    |6                                            5|    |6
+           +---+----v---+            +------------+           +----+----v---+
+        1  |            |            |            |           |             |1
+    -------+            |3         2 |            |3        2 |             +-------
+     vlan  |     s1     +------------+    s2      +-----------+    s3       | vlan
+     100   |            |            |            |           |             | 100
+           |            |            |            |           |             |
+           +------------+            +------------+           +-------------+
+                |4                                                   3|
+                |_____________________________________________________|
+    """
+
+    controller = get_controller_mock()
+    int_manager = INTManager(controller)
+    get_proxy_port_or_raise = MagicMock()
+    int_manager.get_proxy_port_or_raise = get_proxy_port_or_raise
+
+    dpid_a = "00:00:00:00:00:00:00:01"
+    mock_switch_a = get_switch_mock(dpid_a, 0x04)
+    mock_interface_a1 = get_interface_mock("s1-eth1", 1, mock_switch_a)
+    mock_interface_a1.id = f"{dpid_a}:{mock_interface_a1.port_number}"
+    mock_interface_a4 = get_interface_mock("s1-eth4", 4, mock_switch_a)
+    mock_interface_a4.id = f"{dpid_a}:{mock_interface_a4.port_number}"
+    mock_interface_a5 = get_interface_mock("s1-eth5", 5, mock_switch_a)
+    mock_interface_a1.metadata = {"proxy_port": mock_interface_a5.port_number}
+    mock_interface_a4.status = EntityStatus.UP
+    mock_interface_a5.status = EntityStatus.UP
+    mock_interface_a6 = get_interface_mock("s1-eth6", 6, mock_switch_a)
+    mock_interface_a6.status = EntityStatus.UP
+    mock_interface_a5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_a5.port_number,
+                mock_interface_a6.port_number,
+            ]
+        }
+    }
+
+    dpid_z = "00:00:00:00:00:00:00:03"
+    mock_switch_z = get_switch_mock(dpid_z, 0x04)
+    mock_interface_z1 = get_interface_mock("s1-eth1", 1, mock_switch_z)
+    mock_interface_z1.status = EntityStatus.UP
+    mock_interface_z1.id = f"{dpid_z}:{mock_interface_z1.port_number}"
+    mock_interface_z3 = get_interface_mock("s1-eth3", 3, mock_switch_z)
+    mock_interface_z3.status = EntityStatus.UP
+    mock_interface_z3.id = f"{dpid_z}:{mock_interface_z3.port_number}"
+    mock_interface_z5 = get_interface_mock("s1-eth5", 5, mock_switch_z)
+    mock_interface_z1.metadata = {"proxy_port": mock_interface_z5.port_number}
+    mock_interface_z5.status = EntityStatus.UP
+    mock_interface_z6 = get_interface_mock("s1-eth6", 6, mock_switch_z)
+    mock_interface_z6.status = EntityStatus.UP
+    mock_interface_z5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_z5.port_number,
+                mock_interface_z6.port_number,
+            ]
+        }
+    }
+
+    mock_switch_a.get_interface_by_port_no = lambda port_no: {
+        mock_interface_a5.port_number: mock_interface_a5,
+        mock_interface_a6.port_number: mock_interface_a6,
+    }[port_no]
+
+    mock_switch_z.get_interface_by_port_no = lambda port_no: {
+        mock_interface_z5.port_number: mock_interface_z5,
+        mock_interface_z6.port_number: mock_interface_z6,
+    }[port_no]
+
+    pp_a = ProxyPort(controller, source=mock_interface_a5)
+    assert pp_a.source == mock_interface_a5
+    assert pp_a.destination == mock_interface_a6
+    pp_z = ProxyPort(controller, source=mock_interface_z5)
+    assert pp_z.source == mock_interface_z5
+    assert pp_z.destination == mock_interface_z6
+
+    evcs_data = {
+        "ceaf53b16c3a40": {
+            "removed_flows": {
+                "00:00:00:00:00:00:00:01": [
+                    {
+                        "cookie": 12307967605643950656,
+                        "match": {"in_port": 4, "dl_vlan": 2},
+                        "cookie_mask": 18446744073709551615,
+                    }
+                ],
+                "00:00:00:00:00:00:00:03": [
+                    {
+                        "cookie": 12307967605643950656,
+                        "match": {"in_port": 3, "dl_vlan": 2},
+                        "cookie_mask": 18446744073709551615,
+                    }
+                ],
+            },
+            "current_path": [
+                {
+                    "id": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
+                    "endpoint_a": {
+                        "id": "00:00:00:00:00:00:00:01:3",
+                        "name": "s1-eth3",
+                        "port_number": 3,
+                        "mac": "b2:ac:2b:ac:87:bb",
+                        "switch": "00:00:00:00:00:00:00:01",
+                        "type": "interface",
+                        "nni": True,
+                        "uni": False,
+                        "speed": 1250000000.0,
+                        "metadata": {},
+                        "lldp": True,
+                        "active": True,
+                        "enabled": True,
+                        "status": "UP",
+                        "status_reason": [],
+                        "link": "78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0",
+                    },
+                    "endpoint_b": {
+                        "id": "00:00:00:00:00:00:00:02:2",
+                        "name": "s2-eth2",
+                        "port_number": 2,
+                        "mac": "62:50:49:d7:79:8a",
+                        "switch": "00:00:00:00:00:00:00:02",
+                        "type": "interface",
+                        "nni": True,
+                        "uni": False,
+                        "speed": 1250000000.0,
+                        "metadata": {},
+                        "lldp": True,
+                        "active": True,
+                        "enabled": True,
+                        "status": "UP",
+                        "status_reason": [],
+                        "link": "78282c4d5b579265f04ebadc4405ca1b4 9628eb1d684bb45e5d0607fa8b713d0",
+                    },
+                    "metadata": {"s_vlan": {"tag_type": "vlan", "value": 1}},
+                    "active": True,
+                    "enabled": True,
+                    "status": "UP",
+                    "status_reason": [],
+                },
+                {
+                    "id": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                    "endpoint_a": {
+                        "id": "00:00:00:00:00:00:00:02:3",
+                        "name": "s2-eth3",
+                        "port_number": 3,
+                        "mac": "76:82:ef:6e:d2:9d",
+                        "switch": "00:00:00:00:00:00:00:02",
+                        "type": "interface",
+                        "nni": True,
+                        "uni": False,
+                        "speed": 1250000000.0,
+                        "metadata": {},
+                        "lldp": True,
+                        "active": True,
+                        "enabled": True,
+                        "status": "UP",
+                        "status_reason ": [],
+                        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                    },
+                    "endpoint_b": {
+                        "id": "00:00:00:00:00:00:00:03:2",
+                        "name": "s3-eth2",
+                        "port_number": 2,
+                        "mac": "6a:c1: 51:b1:a9:8a",
+                        "switch": "00:00:00:00:00:00:00:03",
+                        "type": "interface",
+                        "nni": True,
+                        "uni": False,
+                        "speed": 1250000000.0,
+                        "metadata": {},
+                        "lldp": True,
+                        "active": True,
+                        "enabled": True,
+                        "status": "UP",
+                        "status_reason": [],
+                        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
+                    },
+                    "metadata": {"s_vlan": {"tag_type": "vlan", "value": 1}},
+                    "active": True,
+                    "enabled": True,
+                    "status": "UP",
+                    "status_reason": [],
+                },
+            ],
+            "evc_id": "ceaf53b16c3a40",
+            "id": "ceaf53b16c3a40",
+            "name": "inter_evpl",
+            "metadata": {
+                "telemetry_request": {},
+                "telemetry": {
+                    "enabled": True,
+                    "status": "UP",
+                    "status_reason": [],
+                    "status_updated_at": "2024-06-11T16:56:29",
+                },
+            },
+            "active": True,
+            "enabled": True,
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {"tag_type": "vlan", "value": 100},
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:03:1",
+                "tag": {"tag_type": "vlan", "value": 100},
+            },
+        }
+    }
+
+    get_proxy_port_or_raise.side_effect = [pp_a, pp_z]
+    int_manager._send_flows = AsyncMock()
+    int_manager._install_int_flows = AsyncMock()
+    int_manager._remove_int_flows = AsyncMock()
+    int_manager.remove_int_flows = AsyncMock()
+    await int_manager.handle_failover_flows(evcs_data, "failover_deployed")
+    assert int_manager._install_int_flows.call_count == 0
+    assert int_manager._remove_int_flows.call_count == 1
+    assert int_manager.remove_int_flows.call_count == 0
+
+    expected_built_flows = {
+        "12307967605643950656": [
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {
+                        "in_port": 4,
+                        "dl_vlan": 2,
+                        "dl_type": 2048,
+                        "nw_proto": 6,
+                    },
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21100,
+                    "table_group": "evpl",
+                    "owner": "telemetry_int",
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [
+                                {"action_type": "add_int_metadata"},
+                                {"action_type": "output", "port": 5},
+                            ],
+                        }
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:01",
+            },
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {
+                        "in_port": 4,
+                        "dl_vlan": 2,
+                        "dl_type": 2048,
+                        "nw_proto": 17,
+                    },
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21100,
+                    "table_group": "evpl",
+                    "owner": "telemetry_int",
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [
+                                {"action_type": "add_int_metadata"},
+                                {"action_type": "output", "port": 5},
+                            ],
+                        }
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:01",
+            },
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {"in_port": 6, "dl_vlan": 2},
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21000,
+                    "table_group": "evpl",
+                    "owner": "telemetry_int",
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "send_report"}],
+                        },
+                        {"instruction_type": "goto_table", "table_id": 2},
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:01",
+            },
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {"in_port": 6, "dl_vlan": 2},
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21000,
+                    "table_group": "evpl",
+                    "owner": "telemetry_int",
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "pop_int"}],
+                        }
+                    ],
+                    "table_id": 2,
+                },
+                "switch": "00:00:00:00:00:00:00:01",
+            },
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {
+                        "in_port": 3,
+                        "dl_vlan": 2,
+                        "dl_type": 2048,
+                        "nw_proto": 6,
+                    },
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21100,
+                    "table_group": "evpl",
+                    "owner": "telemetry_int",
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [
+                                {"action_type": "add_int_metadata"},
+                                {"action_type": "output", "port": 5},
+                            ],
+                        }
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:03",
+            },
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {
+                        "in_port": 3,
+                        "dl_vlan": 2,
+                        "dl_type": 2048,
+                        "nw_proto": 17,
+                    },
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21100,
+                    "table_group": "evpl",
+                    "owner": "telemetry_int",
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [
+                                {"action_type": "add_int_metadata"},
+                                {"action_type": "output", "port": 5},
+                            ],
+                        }
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:03",
+            },
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {"in_port": 6, "dl_vlan": 2},
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21000,
+                    "table_group": "evpl",
+                    "owner": "telemetry_int",
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "send_report"}],
+                        },
+                        {"instruction_type": "goto_table", "table_id": 2},
+                    ],
+                },
+                "switch": "00:00:00:00:00:00:00:03",
+            },
+            {
+                "flow": {
+                    "cookie": 12163852417568094784,
+                    "match": {"in_port": 6, "dl_vlan": 2},
+                    "cookie_mask": 18446744073709551615,
+                    "priority": 21000,
+                    "table_group": "evpl",
+                    "owner": "telemetry_int",
+                    "instructions": [
+                        {
+                            "instruction_type": "apply_actions",
+                            "actions": [{"action_type": "pop_int"}],
+                        }
+                    ],
+                    "table_id": 2,
+                },
+                "switch": "00:00:00:00:00:00:00:03",
+            },
+        ]
+    }
+    serd = json.dumps(expected_built_flows)
+    assert json.dumps(int_manager._remove_int_flows.call_args[0][0]) == serd

--- a/tests/unit/test_flow_builder_intra_evc.py
+++ b/tests/unit/test_flow_builder_intra_evc.py
@@ -733,4 +733,6 @@ def test_build_int_flows_intra_epl_inactive(evcs_data) -> None:
     evcs_data[evc_id]["active"] = True
     cookie = get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
     with pytest.raises(FlowsNotFound):
-        FlowBuilder().build_int_flows(evcs_data, stored_flows)
+        int_manager._validate_evcs_stored_flows(
+            evcs_data, FlowBuilder().build_int_flows(evcs_data, stored_flows)
+        )

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -330,7 +330,7 @@ class TestINTManager:
         monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
 
         int_manager = INTManager(controller)
-        int_manager._remove_int_flows = AsyncMock()
+        int_manager._remove_int_flows_by_cookies = AsyncMock()
         await int_manager.disable_int({}, False)
 
         assert api_mock.add_evcs_metadata.call_count == 1
@@ -369,8 +369,11 @@ class TestINTManager:
         int_manager._validate_map_enable_evcs = MagicMock()
         int_manager._validate_map_enable_evcs.return_value = evcs
         int_manager.flow_builder.build_int_flows = MagicMock()
-        int_manager.flow_builder.build_int_flows.return_value = {}
+        int_manager.flow_builder.build_int_flows.return_value = {
+            0xAA3766C105686749: [MagicMock()]
+        }
         int_manager._add_pps_evc_ids = MagicMock()
+        int_manager._send_flows = AsyncMock()
 
         await int_manager.enable_int(evcs, False)
 
@@ -381,6 +384,7 @@ class TestINTManager:
         telemetry_dict = args[1]["telemetry"]
         expected_keys = ["enabled", "status", "status_reason", "status_updated_at"]
         assert sorted(list(telemetry_dict.keys())) == sorted(expected_keys)
+        assert int_manager._send_flows.call_count == 1
 
         assert telemetry_dict["enabled"] is True
         assert telemetry_dict["status"] == "UP"
@@ -397,7 +401,7 @@ class TestINTManager:
         )
 
         int_manager = INTManager(controller)
-        int_manager._remove_int_flows = AsyncMock()
+        int_manager._remove_int_flows_by_cookies = AsyncMock()
         int_manager._install_int_flows = AsyncMock()
 
         dpid_a = "00:00:00:00:00:00:00:01"
@@ -415,7 +419,7 @@ class TestINTManager:
         await int_manager.redeploy_int(evcs)
 
         assert stored_flows_mock.call_count == 1
-        assert int_manager._remove_int_flows.call_count == 1
+        assert int_manager._remove_int_flows_by_cookies.call_count == 1
         assert api_mock.get_stored_flows.call_count == 1
         assert int_manager._install_int_flows.call_count == 1
 
@@ -442,7 +446,7 @@ class TestINTManager:
         controller._buffers.app.aput = AsyncMock()
         int_manager = INTManager(controller)
         assert len(inter_evc_evpl_flows_data) == 3
-        await int_manager._remove_int_flows(inter_evc_evpl_flows_data)
+        await int_manager._remove_int_flows_by_cookies(inter_evc_evpl_flows_data)
         assert controller._buffers.app.aput.call_count == 3
 
     async def test__install_int_flows(self, inter_evc_evpl_flows_data, monkeypatch):
@@ -504,3 +508,26 @@ class TestINTManager:
         assert int_manager.get_proxy_port_or_raise.call_count == 2
         assert pp.evc_ids.discard.call_count == 2
         pp.evc_ids.discard.assert_called_with(evc_id)
+
+    def test_validate_evc_stored_flows(self) -> None:
+        """Test validate evc stored flows."""
+        controller = MagicMock()
+        int_manager = INTManager(controller)
+        evcs = {
+            "3766c105686749": {
+                "active": True,
+                "uni_a": MagicMock(),
+                "uni_z": MagicMock(),
+            }
+        }
+        stored_flows = {0xAA3766C105686749: [MagicMock()]}
+        int_manager._validate_evcs_stored_flows(evcs, stored_flows)
+
+        with pytest.raises(exceptions.FlowsNotFound):
+            int_manager._validate_evcs_stored_flows(evcs, {0xAA3766C105686749: []})
+
+        with pytest.raises(exceptions.FlowsNotFound):
+            int_manager._validate_evcs_stored_flows(evcs, {})
+
+        evcs["3766c105686749"]["active"] = False
+        int_manager._validate_evcs_stored_flows(evcs, {})

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -550,3 +550,16 @@ class TestINTManager:
 
         evcs["3766c105686749"]["active"] = False
         int_manager._validate_evcs_stored_flows(evcs, {})
+
+    async def test__send_flows(self) -> None:
+        """Test _send_flows."""
+        controller = get_controller_mock()
+        controller._buffers.app.aput = AsyncMock()
+        int_manager = INTManager(controller)
+        switch_flows = {"dpid": []}
+        await int_manager._send_flows(switch_flows, "install")
+        controller._buffers.app.aput.assert_not_called()
+
+        switch_flows = {"dpid": [MagicMock()]}
+        await int_manager._send_flows(switch_flows, "install")
+        controller._buffers.app.aput.assert_called()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -40,7 +40,7 @@ class TestMain:
         endpoint = f"{self.base_endpoint}/evc/enable"
         response = await self.api_client.post(endpoint, json={"evc_ids": [evc_id]})
         assert self.napp.int_manager.enable_int.call_count == 1
-        assert self.napp.int_manager._remove_int_flows.call_count == 1
+        assert self.napp.int_manager._remove_int_flows_by_cookies.call_count == 1
         assert response.status_code == 201
         assert response.json() == [evc_id]
 
@@ -85,7 +85,7 @@ class TestMain:
         }
 
         self.napp.int_manager._validate_map_enable_evcs = MagicMock()
-        self.napp.int_manager._remove_int_flows = AsyncMock()
+        self.napp.int_manager._remove_int_flows_by_cookies = AsyncMock()
         self.napp.int_manager.install_int_flows = AsyncMock()
         endpoint = f"{self.base_endpoint}/evc/redeploy"
         response = await self.api_client.patch(endpoint, json={"evc_ids": [evc_id]})
@@ -385,7 +385,7 @@ class TestMain:
             cookie: {"metadata": {"telemetry": {"enabled": True}}}
         }
         api_mock_int.get_stored_flows.return_value = {cookie: [MagicMock()]}
-        self.napp.int_manager._remove_int_flows = AsyncMock()
+        self.napp.int_manager._remove_int_flows_by_cookies = AsyncMock()
 
         event = KytosEvent(content={"flow": flow, "error_command": "add"})
         await self.napp.on_flow_mod_error(event)
@@ -393,7 +393,7 @@ class TestMain:
         assert api_mock_main.get_evc.call_count == 1
         assert api_mock_int.get_stored_flows.call_count == 1
         assert api_mock_int.add_evcs_metadata.call_count == 1
-        assert self.napp.int_manager._remove_int_flows.call_count == 1
+        assert self.napp.int_manager._remove_int_flows_by_cookies.call_count == 1
 
     async def test_on_mef_eline_evcs_loaded(self):
         """Test on_mef_eline_evcs_loaded."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -418,3 +418,24 @@ class TestMain:
         self.napp.int_manager = MagicMock()
         await self.napp.on_intf_metadata_added(event)
         self.napp.int_manager.handle_pp_metadata_added.assert_called_with(intf)
+
+    async def test_on_failover_deployed(self):
+        """Test on_failover_deployed."""
+        event = KytosEvent(content={})
+        self.napp.int_manager = MagicMock()
+        await self.napp.on_failover_deployed(event)
+        self.napp.int_manager.handle_failover_flows.assert_called()
+
+    async def test_on_failover_link_down(self):
+        """Test on_failover_link_down."""
+        event = KytosEvent(content={})
+        self.napp.int_manager = MagicMock()
+        await self.napp.on_failover_link_down(event)
+        self.napp.int_manager.handle_failover_flows.assert_called()
+
+    async def test_on_failover_old_path(self):
+        """Test on_failover_old_path."""
+        event = KytosEvent(content={})
+        self.napp.int_manager = MagicMock()
+        await self.napp.on_failover_old_path(event)
+        self.napp.int_manager.handle_failover_flows.assert_called()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -261,3 +261,49 @@ def test_set_priority_exc() -> None:
     flow = {"flow": {"priority": 2**16}}
     with pytest.raises(PriorityOverflow):
         utils.set_priority(flow, "some_id")
+
+
+@pytest.mark.parametrize(
+    "link,dpid,expected_vlan",
+    [
+        (
+            {
+                "endpoint_a": {"switch": "00:00:00:00:00:00:00:01"},
+                "endpoint_b": {"switch": "00:00:00:00:00:00:00:02"},
+                "metadata": {"s_vlan": {"tag_type": "vlan", "value": 2}},
+            },
+            "00:00:00:00:00:00:00:01",
+            2,
+        ),
+        (
+            {
+                "endpoint_a": {"switch": "00:00:00:00:00:00:00:01"},
+                "endpoint_b": {"switch": "00:00:00:00:00:00:00:02"},
+                "metadata": {"s_vlan": {"tag_type": "vlan", "value": 2}},
+            },
+            "00:00:00:00:00:00:00:02",
+            2,
+        ),
+        (
+            {
+                "endpoint_a": {"switch": "00:00:00:00:00:00:00:01"},
+                "endpoint_b": {"switch": "00:00:00:00:00:00:00:02"},
+                "metadata": {"s_vlan": {"tag_type": "vlan", "value": 2}},
+            },
+            "00:00:00:00:00:00:00:03",
+            None,
+        ),
+        (
+            {
+                "endpoint_a": {"switch": "00:00:00:00:00:00:00:01"},
+                "endpoint_b": {"switch": "00:00:00:00:00:00:00:02"},
+                "metadata": {},
+            },
+            "00:00:00:00:00:00:00:02",
+            None,
+        ),
+    ],
+)
+def test_get_svlan_dpid_link(link, dpid, expected_vlan) -> None:
+    """Test get_svlan_dpid_link."""
+    assert utils.get_svlan_dpid_link(link, dpid) == expected_vlan

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,8 @@
 """ Support function for main.py """
 
-from napps.kytos.telemetry_int import settings
 from typing import Optional
+
+from napps.kytos.telemetry_int import settings
 
 from .exceptions import FlowsNotFound, PriorityOverflow
 from .kytos_api_helper import get_stored_flows as _get_stored_flows

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 """ Support function for main.py """
 
 from napps.kytos.telemetry_int import settings
+from typing import Optional
 
 from .exceptions import FlowsNotFound, PriorityOverflow
 from .kytos_api_helper import get_stored_flows as _get_stored_flows
@@ -146,3 +147,15 @@ def set_instructions_from_actions(flow: dict) -> dict:
     flow["flow"].pop("actions", None)
     flow["flow"]["instructions"] = instructions
     return flow
+
+
+def get_svlan_dpid_link(link: dict, dpid: str) -> Optional[int]:
+    """Try to get svlan of a link if a dpid matches one of the endpoints."""
+    if any(
+        (
+            link["endpoint_a"]["switch"] == dpid and "s_vlan" in link["metadata"],
+            link["endpoint_b"]["switch"] == dpid and "s_vlan" in link["metadata"],
+        )
+    ):
+        return link["metadata"]["s_vlan"]["value"]
+    return None


### PR DESCRIPTION
Closes #90 
Closes #33 
Closes #38 
Closes #105 

Functionality-wise it's been implemented, it'll keep it in draft while I'm finish the unit tests, and also I need to re-stress test when the INT lab is available again this week. 

### Summary

See updated changelog file 

### Local Tests

- I explored all failover related events with dynamic EVCs, and measured a convergence with a link of the current_path going down on one EVC with `iperf3`, it has been on par with prior metrics compared to how `mef_eline` performs (a few thousands packets retransmissions at 9.5 Gbits/sec):

```
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-60.00  sec  66.0 GBytes  9.44 Gbits/sec  1085             sender
[  4]   0.00-60.00  sec  65.9 GBytes  9.44 Gbits/sec                  receiver
```

```
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-60.00  sec  66.0 GBytes  9.45 Gbits/sec  2914             sender
[  4]   0.00-60.00  sec  66.0 GBytes  9.44 Gbits/sec                  receiver
```

- I also tried to explore with hundreds of EVCs, including static ones, but ended up hitting other issue #105, since that also happens to static ones, it's not related to this current change. I'll fix that on a subsequent PR. 

#### Prior metrics that I shared on Slack


Cool to see `telemetry_int` in action handling ingress fast `failover_path` convergence on INT lab for the first time. I've explored two cases with `iperf3 -c 10.22.22.3 -i 1 -t 20 -b 10G`:

*With one EVC*:

* `mef_eline` TCP packet retransmissions: 1824, 2044, 4017; avg 2628.33
* `telemetry_int` TCP packet retransmissions: 1423, 1816, 4192; avg 2477.0

When handling ingress `failover_path` convergence it's adding roughly up to 25 ms of latency when sending the events internally, and pushing the extra INT flows, which are sent in the socket with asyncio TCP transport with the other `mef_eline` concurrent lower priority flows.

*With 101 INT EVCs*:

* `telemetry_int` TCP packet retransmissions: 3243

*Bottom line so far*: The extra INT new flows didn't add much latency in the total convergence, on average, it's relatively on par with `mef_eline`, from the data plane network traffic point of view, and the switch has been processing them all relatively quickly too.

Data plane traffic hiccup during the failover for both `mef_eline` and `telemetry_int`:

```
[  4]   4.00-5.00   sec  1.11 GBytes  9.56 Gbits/sec    0   2.82 MBytes       
[  4]   5.00-6.00   sec   411 MBytes  3.45 Gbits/sec  2044   1.41 MBytes       
[  4]   6.00-7.00   sec  1.11 GBytes  9.56 Gbits/sec    0   1.41 MBytes       

[  4]   5.00-6.00   sec  1.11 GBytes  9.56 Gbits/sec    0   2.51 MBytes       
[  4]   6.00-7.00   sec  1.01 GBytes  8.71 Gbits/sec    0   2.51 MBytes       
[  4]   7.00-8.00   sec   509 MBytes  4.27 Gbits/sec  1816   1.26 MBytes       
[  4]   8.00-9.00   sec  1.11 GBytes  9.56 Gbits/sec    0   1.26 MBytes       
```


Tox is passing locally but failing on Scrutinizer CI (I believe it's a temporary upstream issue, let's see):

```
---------- coverage: platform linux, python 3.11.9-final-0 -----------
Name                                        Stmts   Miss  Cover
---------------------------------------------------------------
__init__.py                                     0      0   100%
exceptions.py                                  31      2    94%
kytos_api_helper.py                            76     15    80%
main.py                                       272     88    68%
managers/__init__.py                            0      0   100%
managers/flow_builder.py                      159      2    99%
managers/int.py                               353     61    83%
proxy_port.py                                  24      3    88%
settings.py                                    12      0   100%
tests/conftest.py                              18      0   100%
tests/unit/test_flow_builder_failover.py      152      0   100%
tests/unit/test_flow_builder_inter_evc.py      60      0   100%
tests/unit/test_flow_builder_intra_evc.py     152      0   100%
tests/unit/test_int_manager.py                366      0   100%
tests/unit/test_kytos_api_helper.py            63      0   100%
tests/unit/test_main.py                       253      0   100%
tests/unit/test_utils.py                       79      0   100%
utils.py                                       67      0   100%
---------------------------------------------------------------
TOTAL                                        2137    171    92%

============================================================================ 84 passed, 114 warnings in 7.34s ============================================================================
lint: recreate env because env type changed from {'name': 'coverage', 'type': 'VirtualEnvRunner'} to {'name': 'lint', 'type': 'VirtualEnvRunner'}
lint: remove tox env folder /home/viniarck/repos/telemetry_int/.tox/py311
coverage: OK ✔ in 46.29 seconds
lint: install_deps> python -I -m pip install -r requirements/dev.in
lint: commands[0]> python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished black
INFO: Finished pycodestyle
INFO: Finished pylint
:) No issues found.
[isort] Skipped 3 files
  coverage: OK (46.29=setup[38.50]+cmd[7.79] seconds)
  lint: OK (43.95=setup[38.12]+cmd[5.83] seconds)
  congratulations :) (90.27 seconds)
```


### End-to-End Tests

N/A yet