### PR TITLE
Added UI to telemetry_int

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 - Handled ``kytos/mef_eline.error_redeploy_link_down`` event.
 - Handled ``kytos/mef_eline.uni_active_updated`` event.
 - Handled ``kytos/mef_eline.deployed`` event.
+- Added UI for telemetry_int.
 
 Changed
 =======

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -1,0 +1,7 @@
+<template>
+</template>
+<script>
+    module.exports = {
+        props: ["content"],
+    }
+</script>

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -6,7 +6,7 @@
                 <k-accordion-item title="Options">
                     <k-button-group>
                         <k-button icon="comment" title="Enable Selected" tooltip="Enable INT on selected EVCs" @click="enableSelectedEVCs()"></k-button>
-                        <k-button icon="comment-slash" title="Disable Selected" tooltip="Disable INT on selected EVCs" @click="disableSelectedEVCs()"></k-button>
+                        <k-button icon="comment-slash" title="Disable Selected" tooltip="Disable INT on selected EVCs" @click="displayModal()"></k-button>
                         <k-button icon="truck-moving" title="Redeploy Selected" tooltip="Redeploy INT on selected EVCs" @click="redeploySelectedEVCs()"></k-button>
                     <k-button-group>
                     <k-checkbox title="Force" v-model:model="forceOption" :value="true"></k-checkbox>
@@ -76,6 +76,31 @@
                 </k-accordion-item>
             </k-accordion-item>
         </k-accordion>
+        <template v-if="showDelModal">
+            <div class="modal-mask">
+              <div class="modal-wrapper">
+                <div class="modal-container">
+                  <div class="modal-header">
+                    <slot name="header">
+                    </slot>
+                  </div>
+                  <div class="modal-body">
+                    <slot name="body">
+                        Disable Telemetry INT on selected EVCs? 
+                    </slot>
+                  </div>
+                  <div class="modal-footer">
+                    <slot name="footer">
+                      <k-button tooltip="Cancel" title="Cancel" @click="modalClose">
+                      </k-button>
+                      <k-button id="modalOK" tooltip="Delete" title="Delete" @click="modalOK">
+                      </k-button>
+                    </slot>
+                  </div>
+                </div>
+              </div>
+            </div>
+        </template>
     </div>
 </template>
 <script>
@@ -97,7 +122,8 @@
                 sortedColumnName: ["", 0],
                 sortIdentifier: {id: 0, name: 1, active: 2, enabled: 3, status: 4, status_reason: 5, status_updated_at: 6},
                 sortSymbols: ["▲", "▼"],
-                sortIdentifierList: ["", "", "", "", "", "", ""]
+                sortIdentifierList: ["", "", "", "", "", "", ""],
+                showDelModal: false
             }
         },
         methods: {
@@ -124,6 +150,7 @@
                 }
                 this.setSortedColumn()
             },
+            //Sets table sort symbol
             setSortedColumn() {
                 this.sortIdentifierList = ["", "", "", "", "", "", ""]
                 this.sortIdentifierList[this.sortIdentifier[this.sortedColumnName[0]]] = this.sortSymbols[this.sortedColumnName[1]]
@@ -259,6 +286,23 @@
                     }
                     this.content.push(EVC_Obj)
                 }
+            },
+            //Displays modal
+            displayModal() {
+                this.showDelModal = true
+            },
+            modalClose() {
+                /**
+                 * Modal window - Close (X) buttom
+                 */
+                this.showDelModal = false
+            },
+            modalOK() {
+                /**
+                 * Modal window - OK buttom
+                 */
+                this.showDelModal = false
+                this.disableSelectedEVCs()
             }
         },
         computed: {
@@ -377,5 +421,56 @@
     .sortable-column:hover {
         color: #eee;
         background-color: #322c5d;
+    }
+    /* Modal windows */
+    .modal-mask {
+        position: fixed;
+        z-index: 9998;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+        display: table;
+        transition: opacity 0.3s ease;
+    }
+    .modal-wrapper {
+        display: table-cell;
+        vertical-align: middle;
+    }
+    .modal-container {
+        width: 300px;
+        margin: 0px auto;
+        padding: 10px 10px 10px 20px;;
+        background-color: #e8e8e8;
+        border-radius: 2px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
+        transition: all 0.3s ease;
+        font-family: Helvetica, Arial, sans-serif;
+    }
+    .modal-body {
+        margin: 20px 0;
+    }
+    .modal-default-button {
+        float: right;
+    }
+    .modal-enter {
+        opacity: 0;
+    }
+    .modal-leave-active {
+        opacity: 0;
+    }
+    .modal-enter .modal-container,
+    .modal-leave-active .modal-container {
+        -webkit-transform: scale(1.1);
+        transform: scale(1.1);
+    }
+    .modal-footer {
+        justify-content: end; 
+        display: flex;
+    }
+    #modalOK {
+        color: #ffc5c5;
+        background: #be0000;
     }
 </style>

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -2,7 +2,6 @@
     <div class="telemetryINT_container">
         <k-accordion>
             <k-accordion-item title="EVC Telemetry Info">
-                <!-- <k-context-panel v-if="is_empty" title="Empty Result" icon="gear"></k-context-panel> -->
                 <k-accordion-item title="Options">
                     <k-button-group>
                         <k-button icon="comment" title="Enable Selected" tooltip="Enable INT on selected EVCs" @click="enableSelectedEVCs()"></k-button>
@@ -17,7 +16,7 @@
                             <thead>
                                 <tr>
                                     <th rowspan="2" colspan="1"></th>
-                                    <th rowspan="2" colspan="1">ID</th> 
+                                    <th rowspan="2" colspan="1">ID</th>
                                     <th rowspan="2" colspan="1">Name</th>
                                     <th rowspan="2" colspan="1">Active</th>
                                     <th rowspan="1" colspan="4">Telemetry</th>
@@ -26,7 +25,7 @@
                                     <th>Enabled</th>
                                     <th>Status</th>
                                     <th>Status Reason</th>
-                                    <th>Status Updated At</th>                   
+                                    <th>Status Updated At</th>
                                 </tr>
                                 <tr>
                                     <th>
@@ -63,9 +62,9 @@
                                     <td>{{item.enabled}}</td>
                                     <td :class="statusColor(item)">{{item.status}}</td>
                                     <td>{{item.status_reason}}</td>
-                                    <td>{{item.status_updated_at}}</td>                  
+                                    <td>{{item.status_updated_at}}</td>
                                 </tr>
-                            </tbody>             
+                            </tbody>
                         </table>
                     </div>
                 </k-accordion-item>
@@ -188,9 +187,6 @@
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
                 });
-            },
-            refresh() {
-
             }
         },
         computed: {

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -308,6 +308,10 @@
                     this.content.push(EVC_Obj)
                 }
             },
+            //Formats status reason data for table
+            splitStatusReasons(statusReasons) {
+                return statusReasons.toString()
+            },
             //Displays modal
             displayModal() {
                 this.showDelModal = true

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -17,7 +17,7 @@
                     here are three sections: Switches, Links, and Interfaces
                 -->
                 <k-accordion-item title="Table">
-                    <div class="data_table">
+                    <div class="INT_table">
                         <table>
                             <thead>
                                 <tr>
@@ -235,7 +235,7 @@
     }
 </script>
 <style>
-    .data_table {
+    .INT_table {
       color: #ccc;
       text-align: center;
       margin: 0 auto;
@@ -243,31 +243,31 @@
       padding: 0.5em 0 1em 0.3em;
       font-size: 0.8em;
       overflow-x: hidden;
-      overflow-y: auto;
+      overflow-y: visible;
     }
-    .data_table table{
+    .INT_table table{
       display: table;
       width: 100%;
     }
-    .data_table thead{
+    .INT_table thead{
       font-weight: bold;
       background: #554077;
     }
-    .data_table th{
+    .INT_table th{
       padding: 0.6em 0 0.6em 0;
       vertical-align: middle;
       border: 1px solid;
     }
-    .data_table td{
+    .INT_table td{
       vertical-align: middle;
       padding: 0.45em 0 0.45em 0;
       word-break: break-all;
       border: 1px solid;
     }
-    .data_table tbody tr:nth-child(even) {
+    .INT_table tbody tr:nth-child(even) {
       background: #313131;
     }
-    .data_table tbody tr:hover {
+    .INT_table tbody tr:hover {
         color: #eee;
         background-color: #666;
     }

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -176,7 +176,7 @@
                 request.done(function(data) {
                     let notification = {
                         icon: 'check',
-                        title: 'EVCs with ID: ' + this.selectedEVCs.toString() + ' enabled.',
+                        title: 'EVCs with ID: ' + self.selectedEVCs.toString() + ' enabled.',
                         description: ''
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
@@ -213,7 +213,7 @@
                 request.done(function(data) {
                     let notification = {
                         icon: 'check',
-                        title: 'EVCs with ID: ' + this.selectedEVCs.toString() + ' disabled.',
+                        title: 'EVCs with ID: ' + self.selectedEVCs.toString() + ' disabled.',
                         description: ''
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
@@ -247,7 +247,7 @@
                 request.done(function(data) {
                     let notification = {
                         icon: 'check',
-                        title: 'EVCs with ID: ' + this.selectedEVCs.toString() + ' redeployed.',
+                        title: 'EVCs with ID: ' + self.selectedEVCs.toString() + ' redeployed.',
                         description: ''
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -21,17 +21,17 @@
                         <table>
                             <thead>
                                 <tr>
-                                    <th rowspan="2" colspan="1"></th>
-                                    <th rowspan="2" colspan="1" @click="changeSortedColumn('ID')">ID</th>
-                                    <th rowspan="2" colspan="1" @click="changeSortedColumn('NAME')">Name</th>
-                                    <th rowspan="2" colspan="1" @click="changeSortedColumn('ACTIVE')">Active</th>
+                                    <th class="sortable-column" rowspan="2" colspan="1"></th>
+                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('ID')">ID &nbsp;{{sortIdentifier[0]}}</th>
+                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('NAME')">Name &nbsp;{{sortIdentifier[1]}}</th>
+                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('ACTIVE')">Active &nbsp;{{sortIdentifier[2]}}</th>
                                     <th rowspan="1" colspan="4">Telemetry</th>
                                 </tr>
                                 <tr>
-                                    <th @click="changeSortedColumn('ENABLED')">Enabled</th>
-                                    <th @click="changeSortedColumn('STATUS')">Status</th>
-                                    <th @click="changeSortedColumn('STATUS_REASON')">Status Reason</th>
-                                    <th @click="changeSortedColumn('STATUS_UPDATED_AT')">Status Updated At</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('ENABLED')">Enabled &nbsp;{{sortIdentifier[3]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('STATUS')">Status &nbsp;{{sortIdentifier[4]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('STATUS_REASON')">Status Reason &nbsp;{{sortIdentifier[5]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('STATUS_UPDATED_AT')">Status Updated At &nbsp;{{sortIdentifier[6]}}</th>
                                 </tr>
                                 <tr>
                                     <th>
@@ -94,7 +94,8 @@
                 ],
                 selectedEVCs: [],
                 forceOption: [],
-                sortedColumnName: ["", 0]
+                sortedColumnName: ["", 0],
+                sortIdentifier: ["", "", "", "", "", "", ""]
             }
         },
         methods: {
@@ -118,6 +119,60 @@
                     this.sortedColumnName[1] = 1
                 } else {
                     this.sortedColumnName = [name, 0]
+                }
+                switch(name) {
+                    case "ID":
+                        if (this.sortedColumnName[1]) {
+                            this.sortIdentifier = ["▼", "", "", "", "", "", ""]
+                        } else {
+                            this.sortIdentifier = ["▲", "", "", "", "", "", ""]
+                        }
+                        break;
+                    case "NAME":
+                        if (this.sortedColumnName[1]) {
+                            this.sortIdentifier = ["", "▼", "", "", "", "", ""]
+                        } else {
+                            this.sortIdentifier = ["", "▲", "", "", "", "", ""]
+                        }
+                        break;
+                    case "ACTIVE":
+                        if (this.sortedColumnName[1]) {
+                            this.sortIdentifier = ["", "", "▼", "", "", "", ""]
+                        } else {
+                            this.sortIdentifier = ["", "", "▲", "", "", "", ""]
+                        }
+                        break;
+                    case "ENABLED":
+                        if (this.sortedColumnName[1]) {
+                            this.sortIdentifier = ["", "", "", "▼", "", "", ""]
+                        } else {
+                            this.sortIdentifier = ["", "", "", "▲", "", "", ""]
+                        }
+                        break;
+                    case "STATUS":
+                        if (this.sortedColumnName[1]) {
+                            this.sortIdentifier = ["", "", "", "", "▼", "", ""]
+                        } else {
+                            this.sortIdentifier = ["", "", "", "", "▲", "", ""]
+                        }
+                        break;
+                    case "STATUS_REASON":
+                        if (this.sortedColumnName[1]) {
+                            this.sortIdentifier = ["", "", "", "", "", "▼", ""]
+                        } else {
+                            this.sortIdentifier = ["", "", "", "", "", "▲", ""]
+                        }
+                        break;
+                    case "STATUS_UPDATED_AT":
+                        if (this.sortedColumnName[1]) {
+                            this.sortIdentifier = ["", "", "", "", "", "", "▼"]
+                        } else {
+                            this.sortIdentifier = ["", "", "", "", "", "", "▲"]
+                        }
+                        break;
+                    default:
+                        this.sortIdentifier = ["", "", "", "", "", "", ""]
+                        break;
                 }
             },
             //API request to enable EVCs selected within UI
@@ -459,5 +514,9 @@
     .k-checkbox-wrap {
         background: none;
         margin-left: 1em;
+    }
+    .sortable-column:hover {
+        color: #eee;
+        background-color: #322c5d;
     }
 </style>

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -180,7 +180,6 @@
                 request.done(function(data) {
                 });
                 request.fail(function(data) {
-                    console.log(data)
                     let notification = {
                         icon: 'cog',
                         title: 'Could not redeploy INT on EVCs',

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -174,7 +174,7 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/enable",
                                 async: true});
                 request.done(function(data) {
-                    get_EVCs()
+                    self.get_EVCs()
                 });
                 request.fail(function(data) {
                     let notification = {
@@ -204,7 +204,7 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/disable",
                                 async: true});
                 request.done(function(data) {
-                    get_EVCs()
+                    self.get_EVCs()
                 });
                 request.fail(function(data) {
                     let notification = {
@@ -231,7 +231,7 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/redeploy",
                                 async: true});
                 request.done(function(data) {
-                    get_EVCs()
+                    self.get_EVCs()
                 });
                 request.fail(function(data) {
                     let notification = {

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -123,7 +123,8 @@
                 sortIdentifier: {id: 0, name: 1, active: 2, enabled: 3, status: 4, status_reason: 5, status_updated_at: 6},
                 sortSymbols: ["▲", "▼"],
                 sortIdentifierList: ["", "", "", "", "", "", ""],
-                showDelModal: false
+                showDelModal: false,
+                currentTableData: []
             }
         },
         methods: {
@@ -179,8 +180,8 @@
                         title: 'EVCs with ID: ' + self.selectedEVCs.toString() + ' enabled.',
                         description: ''
                     }
-                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                 });
                 request.fail(function(data) {
                     let notification = {
@@ -188,8 +189,8 @@
                         title: 'Could not enable INT on EVCs',
                         description: data.status.toString() + ": " + data.responseJSON.description
                     }
-                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                 });
             },
             //API request to disable EVCs selected within UI
@@ -216,8 +217,8 @@
                         title: 'EVCs with ID: ' + self.selectedEVCs.toString() + ' disabled.',
                         description: ''
                     }
-                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                 });
                 request.fail(function(data) {
                     let notification = {
@@ -225,8 +226,8 @@
                         title: 'Could not disable INT on EVCs',
                         description: data.status.toString() + ": " + data.responseJSON.description
                     }
-                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                 });
             },
             //API request to redeploy EVCs selected within UI
@@ -250,8 +251,8 @@
                         title: 'EVCs with ID: ' + self.selectedEVCs.toString() + ' redeployed.',
                         description: ''
                     }
-                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                 });
                 request.fail(function(data) {
                     let notification = {
@@ -259,8 +260,8 @@
                         title: 'Could not redeploy INT on EVCs',
                         description: data.status.toString() + ": " + data.responseJSON.description
                     }
-                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                 });
             },
             //API request for EVC data
@@ -288,7 +289,7 @@
              * @description Extracts only the required information for the telemetry_int table from the mef_eline EVC data.
              */
             extract_TelemetryINTData(EVC_Data) {
-                this.content = []
+                this.currentTableData = []
                 for (let EVC in EVC_Data) {
                     let EVC_Obj = {}
                     EVC_Obj["active"] = EVC_Data[EVC].active
@@ -305,7 +306,7 @@
                         EVC_Obj["status_reason"] = "N/A"
                         EVC_Obj["status_updated_at"] = "N/A"
                     }
-                    this.content.push(EVC_Obj)
+                    this.currentTableData.push(EVC_Obj)
                 }
             },
             //Formats status reason data for table
@@ -333,7 +334,12 @@
         computed: {
             //Filters the content obtained via the prop from main.kytos based on the textFilters/searchColumns and then the column ordering
             filtered_EVCData: function() {
-                let current_data = this.$kytos.toRaw(this.content)
+                let current_data = []
+                if(this.currentTableData == undefined || this.currentTableData.length == 0) {
+                    current_data = this.$kytos.toRaw(this.content)
+                } else {
+                    current_data = this.currentTableData
+                }
                 //Filter based on the search columns
                 if (current_data) {
                     let filtered_data = current_data.filter((EVC) => {

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -1,7 +1,282 @@
 <template>
+    <div class="telemetryINT_container">
+        <k-accordion>
+            <k-accordion-item title="EVC Telemetry Info">
+                <!-- <k-context-panel v-if="is_empty" title="Empty Result" icon="gear"></k-context-panel> -->
+                <k-accordion-item title="Options">
+                    <k-button-group>
+                        <k-button icon="comment" title="Enable Selected" tooltip="Enable INT on selected EVCs" @click="enableSelectedEVCs()"></k-button>
+                        <k-button icon="comment-slash" title="Disable Selected" tooltip="Disable INT on selected EVCs" @click="disableSelectedEVCs()"></k-button>
+                        <k-button icon="truck-moving" title="Redeploy Selected" tooltip="Redeploy INT on selected EVCs" @click="redeploySelectedEVCs()"></k-button>
+                    <k-button-group>
+                    <k-checkbox title="Force" v-model:model="forceOption" :value="true"></k-checkbox>
+                </k-accordion-item>
+                <k-accordion-item title="Table">
+                    <div class="data_table">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th rowspan="2" colspan="1"></th>
+                                    <th rowspan="2" colspan="1">ID</th> 
+                                    <th rowspan="2" colspan="1">Name</th>
+                                    <th rowspan="2" colspan="1">Active</th>
+                                    <th rowspan="1" colspan="4">Telemetry</th>
+                                </tr>
+                                <tr>
+                                    <th>Enabled</th>
+                                    <th>Status</th>
+                                    <th>Status Reason</th>
+                                    <th>Status Updated At</th>                   
+                                </tr>
+                                <tr>
+                                    <th>
+                                    </th>
+                                    <th>
+                                        <input v-model="EVCTextFilter[0][1]"></input>
+                                    </th>
+                                    <th>
+                                        <input v-model="EVCTextFilter[1][1]"></input>
+                                    </th>
+                                    <th>
+                                        <input v-model="EVCTextFilter[2][1]"></input>
+                                    </th>
+                                    <th>
+                                        <input v-model="EVCTextFilter[3][1]"></input>
+                                    </th>
+                                    <th>
+                                        <input v-model="EVCTextFilter[4][1]"></input>
+                                    </th>
+                                    <th>
+                                        <input v-model="EVCTextFilter[5][1]"></input>
+                                    </th>
+                                    <th>
+                                        <input v-model="EVCTextFilter[6][1]"></input>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr v-for="(item, index) in filtered_EVCData">
+                                    <td><k-checkbox v-model:model="selectedEVCs" :value="item.id"></k-checkbox></td>
+                                    <td>{{item.id}}</td>
+                                    <td>{{item.name}}</td>
+                                    <td>{{item.active}}</td>
+                                    <td>{{item.enabled}}</td>
+                                    <td :class="statusColor(item)">{{item.status}}</td>
+                                    <td>{{item.status_reason}}</td>
+                                    <td>{{item.status_updated_at}}</td>                  
+                                </tr>
+                            </tbody>             
+                        </table>
+                    </div>
+                </k-accordion-item>
+            </k-accordion-item>
+        </k-accordion>
+    </div>
 </template>
 <script>
     module.exports = {
         props: ["content"],
+        data: function() {
+            return {
+                EVCTextFilter: [
+                    ["id", ""],
+                    ["name", ""],
+                    ["active", ""],
+                    ["enabled", ""],
+                    ["status", ""],
+                    ["status_reason", ""],
+                    ["status_updated_at", ""]
+                ],
+                selectedEVCs: [],
+                forceOption: []
+            }
+        },
+        methods: {
+            statusColor(data) {
+            /**
+             * @param {Object} data - The normal table row object containing:
+             * @param {string} data.status - The status of the device the Object references.
+             * @param {string} data.status_reason - The status_reason of the device the Object references.
+             * @param {boolean} data.enabled - State of the device the Object references. Enabled or Disabled.
+             * @returns {string} Returns a string that acts as the class for current HTML element.
+             * @description Sets color for current status table cell.
+             */
+                switch(true) {
+                    case (data.status == "UP"):
+                        return "green";
+                    case (data.status == "DOWN"):
+                        return "red";
+                }
+            },
+            enableSelectedEVCs() {
+                var self = this
+                let evc_id = []
+                for (const EVC in this.content) {
+                    evc_id.push(EVC.toString())
+                }
+                let payload = {evc_ids: this.selectedEVCs}
+                if (this.forceOption[0]) {
+                    payload["force"] = true
+                }
+                let request = $.ajax({
+                                type:"POST",
+                                dataType: "json",
+                                contentType: "application/json",
+                                data: JSON.stringify(payload),
+                                url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/enable",
+                                async: true});
+                request.done(function(data) {
+                });
+                request.fail(function(data) {
+                    let notification = {
+                        icon: 'cog',
+                        title: 'Could not enable INT on EVCs',
+                        description: data.status.toString()
+                    }
+                    self.$kytos.eventBus.$emit("setNotification", notification)
+                });
+            },
+            disableSelectedEVCs() {
+                var self = this
+                let evc_id = []
+                for (const EVC in this.content) {
+                    evc_id.push(EVC.toString())
+                }
+                let payload = {evc_ids: this.selectedEVCs}
+                if (this.forceOption[0]) {
+                    payload["force"] = true
+                }
+                let request = $.ajax({
+                                type:"POST",
+                                dataType: "json",
+                                contentType: "application/json",
+                                data: JSON.stringify(payload),
+                                url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/disable",
+                                async: true});
+                request.done(function(data) {
+                });
+                request.fail(function(data) {
+                    let notification = {
+                        icon: 'cog',
+                        title: 'Could not disable INT on EVCs',
+                        description: data.status.toString()
+                    }
+                    self.$kytos.eventBus.$emit("setNotification", notification)
+                });
+            },
+            redeploySelectedEVCs() {
+                var self = this
+                let evc_id = []
+                for (const EVC in this.content) {
+                    evc_id.push(EVC.toString())
+                }
+                let payload = {evc_ids: this.selectedEVCs}
+                let request = $.ajax({
+                                type:"PATCH",
+                                dataType: "json",
+                                contentType: "application/json",
+                                data: JSON.stringify(payload),
+                                url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/redeploy",
+                                async: true});
+                request.done(function(data) {
+                });
+                request.fail(function(data) {
+                    let notification = {
+                        icon: 'cog',
+                        title: 'Could not redeploy INT on EVCs',
+                        description: data.status.toString()
+                    }
+                    self.$kytos.eventBus.$emit("setNotification", notification)
+                });
+            },
+            refresh() {
+
+            }
+        },
+        computed: {
+            filtered_EVCData: function() {
+                let current_data = structuredClone(this.$kytos.toRaw(this.content))
+                for (const tableColumn of this.EVCTextFilter) {
+                    if (tableColumn[1] != "") {
+                        for (const EVC in current_data) {
+                            var separatedFilter = tableColumn[1].toString()
+                            var separatedProperty = current_data[EVC][tableColumn[0]].toString()
+                            if (!(separatedProperty.includes(separatedFilter) || separatedFilter.includes(separatedProperty))) {
+                                delete current_data[EVC]
+                            }
+                        }
+                    }
+                }
+                return current_data
+            }
+        },
+        mounted() {
+            // Make the panel fill the screen except the left menu width
+            if (JSON.parse(localStorage.getItem('telemetry_int/k-info-panel/show_telemetry_int_data/EVCTextFilter'))) {
+                this.EVCTextFilter = JSON.parse(localStorage.getItem('telemetry_int/k-info-panel/show_telemetry_int_data/EVCTextFilter'));
+            }
+        },
+        watch: {
+            EVCTextFilter: {
+                handler: function() {
+                    localStorage.setItem('telemetry_int/k-info-panel/show_telemetry_int_data/EVCTextFilter', JSON.stringify(this.EVCTextFilter))
+                },
+                deep: true
+            }
+        }
     }
 </script>
+<style>
+    .data_table {
+      color: #ccc;
+      max-height: 250px;
+      text-align: center;
+      margin: 0 auto;
+      display: block;
+      padding: 0.5em 0 1em 0.3em;
+      font-size: 0.8em;
+      overflow-x: hidden;
+      overflow-y: auto;
+    }
+    .data_table table{
+      display: table;
+      width: 100%;
+    }
+    .data_table thead{
+      font-weight: bold;
+      background: #554077;
+    }
+    .data_table th{
+      padding: 0.6em 0 0.6em 0;
+      vertical-align: middle;
+      border: 1px solid;
+    }
+    .data_table td{
+      vertical-align: middle;
+      padding: 0.45em 0 0.45em 0;
+      word-break: break-all;
+      border: 1px solid;
+    }
+    .data_table tbody tr:nth-child(even) {
+      background: #313131;
+    }
+    .data_table tbody tr:hover {
+        color: #eee;
+        background-color: #666;
+    }
+    .green {
+        background-color: #8bc34a;
+        color: #222;
+    }
+    .red {
+        background-color: #dd2c00;
+        color: #222;
+    }
+    .k-info-panel:has(.telemetryINT_container) {
+        width: calc(100% - 305px) !important; /* overrides the width of the parent panel if it loads the mef_eline container */
+    }
+    .k-checkbox-wrap {
+        background: none;
+        margin-left: 1em;
+    }
+</style>

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -334,12 +334,7 @@
         computed: {
             //Filters the content obtained via the prop from main.kytos based on the textFilters/searchColumns and then the column ordering
             filtered_EVCData: function() {
-                let current_data = []
-                if(this.currentTableData == undefined || this.currentTableData.length == 0) {
-                    current_data = this.$kytos.toRaw(this.content)
-                } else {
-                    current_data = this.currentTableData
-                }
+                let current_data = this.$kytos.toRaw(this.currentTableData)
                 //Filter based on the search columns
                 if (current_data) {
                     let filtered_data = current_data.filter((EVC) => {
@@ -381,6 +376,8 @@
         },
         //Extracts data from localStorage (if available) when first mounted.
         mounted() {
+            // Add content to table data
+            this.currentTableData = this.content
             // Make the panel fill the screen except the left menu width
             if (JSON.parse(localStorage.getItem('telemetry_int/k-info-panel/show_telemetry_int_data/EVCTextFilter'))) {
                 this.EVCTextFilter = JSON.parse(localStorage.getItem('telemetry_int/k-info-panel/show_telemetry_int_data/EVCTextFilter'));
@@ -391,6 +388,14 @@
             EVCTextFilter: {
                 handler: function() {
                     localStorage.setItem('telemetry_int/k-info-panel/show_telemetry_int_data/EVCTextFilter', JSON.stringify(this.EVCTextFilter))
+                },
+                deep: true
+            },
+            content: {
+                handler: function() {
+                    this.currentTableData = this.content
+                    console.log(this.content)
+                    console.log(this.currentTableData)
                 },
                 deep: true
             }

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -130,7 +130,7 @@
                     let notification = {
                         icon: 'cog',
                         title: 'Could not enable INT on EVCs',
-                        description: data.status.toString()
+                        description: data.status.toString() + ": " + data.responseJSON.description
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
                 });
@@ -158,7 +158,7 @@
                     let notification = {
                         icon: 'cog',
                         title: 'Could not disable INT on EVCs',
-                        description: data.status.toString()
+                        description: data.status.toString() + ": " + data.responseJSON.description
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
                 });
@@ -180,10 +180,11 @@
                 request.done(function(data) {
                 });
                 request.fail(function(data) {
+                    console.log(data)
                     let notification = {
                         icon: 'cog',
                         title: 'Could not redeploy INT on EVCs',
-                        description: data.status.toString()
+                        description: data.status.toString() + ": " + data.responseJSON.description
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
                 });

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -189,6 +189,7 @@
                         description: data.status.toString() + ": " + data.responseJSON.description
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
+                    self.get_EVCs()
                 });
             },
             //API request to disable EVCs selected within UI
@@ -225,6 +226,7 @@
                         description: data.status.toString() + ": " + data.responseJSON.description
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
+                    self.get_EVCs()
                 });
             },
             //API request to redeploy EVCs selected within UI
@@ -258,6 +260,7 @@
                         description: data.status.toString() + ": " + data.responseJSON.description
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
+                    self.get_EVCs()
                 });
             },
             //API request for EVC data

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -174,6 +174,12 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/enable",
                                 async: true});
                 request.done(function(data) {
+                    let notification = {
+                        icon: 'check',
+                        title: 'EVCs with ID: ' + this.selectedEVCs.toString() + ' enabled.',
+                        description: ''
+                    }
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
                 });
                 request.fail(function(data) {
@@ -204,6 +210,12 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/disable",
                                 async: true});
                 request.done(function(data) {
+                    let notification = {
+                        icon: 'check',
+                        title: 'EVCs with ID: ' + this.selectedEVCs.toString() + ' disabled.',
+                        description: ''
+                    }
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
                 });
                 request.fail(function(data) {
@@ -231,6 +243,12 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/redeploy",
                                 async: true});
                 request.done(function(data) {
+                    let notification = {
+                        icon: 'check',
+                        title: 'EVCs with ID: ' + this.selectedEVCs.toString() + ' redeployed.',
+                        description: ''
+                    }
+                    self.$kytos.eventBus.$emit("setNotification", notification)
                     self.get_EVCs()
                 });
                 request.fail(function(data) {

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -194,6 +194,7 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/enable",
                                 async: true});
                 request.done(function(data) {
+                    get_EVCs()
                 });
                 request.fail(function(data) {
                     let notification = {
@@ -223,6 +224,7 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/disable",
                                 async: true});
                 request.done(function(data) {
+                    get_EVCs()
                 });
                 request.fail(function(data) {
                     let notification = {
@@ -249,6 +251,7 @@
                                 url: this.$kytos_server_api + "kytos/telemetry_int/v1/evc/redeploy",
                                 async: true});
                 request.done(function(data) {
+                    get_EVCs()
                 });
                 request.fail(function(data) {
                     let notification = {
@@ -258,6 +261,51 @@
                     }
                     self.$kytos.eventBus.$emit("setNotification", notification)
                 });
+            },
+            //API request for EVC data
+            get_EVCs() {
+                var self = this
+                let request = $.ajax({
+                                type:"GET",
+                                dataType: "json",
+                                url: this.$kytos_server_api + "kytos/mef_eline/v2/evc/",
+                                async: true});
+                request.done(function(data) {
+                    self.extract_TelemetryINTData(data)
+                });
+                request.fail(function(data) {
+                    let notification = {
+                        icon: 'cog',
+                        title: 'Could not retrieve EVCs',
+                        description: data.status.toString() + ": " + data.responseJSON.description
+                    }
+                    self.$kytos.eventBus.$emit("setNotification", notification)
+                });
+            },
+            /**
+             * @param {Object} EVC_Data - The EVC data from mef_eline.
+             * @description Extracts only the required information for the telemetry_int table from the mef_eline EVC data.
+             */
+            extract_TelemetryINTData(EVC_Data) {
+                this.content = []
+                for (let EVC in EVC_Data) {
+                    let EVC_Obj = {}
+                    EVC_Obj["active"] = EVC_Data[EVC].active
+                    EVC_Obj["id"] = EVC_Data[EVC].id
+                    EVC_Obj["name"] = EVC_Data[EVC].name
+                    if (EVC_Data[EVC].metadata?.telemetry) {
+                        EVC_Obj["enabled"] = EVC_Data[EVC].metadata.telemetry.enabled.toString()
+                        EVC_Obj["status"] = EVC_Data[EVC].metadata.telemetry.status
+                        EVC_Obj["status_reason"] = this.splitStatusReasons(EVC_Data[EVC].metadata.telemetry.status_reason)
+                        EVC_Obj["status_updated_at"] = EVC_Data[EVC].metadata.telemetry.status_updated_at
+                    } else {
+                        EVC_Obj["enabled"] = "N/A"
+                        EVC_Obj["status"] = "N/A"
+                        EVC_Obj["status_reason"] = "N/A"
+                        EVC_Obj["status_updated_at"] = "N/A"
+                    }
+                    this.content.push(EVC_Obj)
+                }
             }
         },
         computed: {

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -237,7 +237,6 @@
 <style>
     .data_table {
       color: #ccc;
-      max-height: 250px;
       text-align: center;
       margin: 0 auto;
       display: block;

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -119,7 +119,6 @@
                 } else {
                     this.sortedColumnName = [name, 0]
                 }
-                console.log(this.sortedColumnName)
             },
             //API request to enable EVCs selected within UI
             enableSelectedEVCs() {

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -2,6 +2,7 @@
     <div class="telemetryINT_container">
         <k-accordion>
             <k-accordion-item title="EVC Telemetry Info">
+                <!-- Buttons for utilizing the given action/request on the selected EVCs -->
                 <k-accordion-item title="Options">
                     <k-button-group>
                         <k-button icon="comment" title="Enable Selected" tooltip="Enable INT on selected EVCs" @click="enableSelectedEVCs()"></k-button>
@@ -10,6 +11,11 @@
                     <k-button-group>
                     <k-checkbox title="Force" v-model:model="forceOption" :value="true"></k-checkbox>
                 </k-accordion-item>
+                <!--
+                    Sections/Tables:
+                    Each follow the same structure as seen below
+                    here are three sections: Switches, Links, and Interfaces
+                -->
                 <k-accordion-item title="Table">
                     <div class="data_table">
                         <table>
@@ -107,6 +113,7 @@
                         return "red";
                 }
             },
+            //API request to enable EVCs selected within UI
             enableSelectedEVCs() {
                 var self = this
                 let evc_id = []
@@ -135,6 +142,7 @@
                     self.$kytos.eventBus.$emit("setNotification", notification)
                 });
             },
+            //API request to disable EVCs selected within UI
             disableSelectedEVCs() {
                 var self = this
                 let evc_id = []
@@ -163,6 +171,7 @@
                     self.$kytos.eventBus.$emit("setNotification", notification)
                 });
             },
+            //API request to redeploy EVCs selected within UI
             redeploySelectedEVCs() {
                 var self = this
                 let evc_id = []
@@ -190,6 +199,7 @@
             }
         },
         computed: {
+            //Filters the content obtained via the prop from main.kytos based on the textFilters/searchColumns
             filtered_EVCData: function() {
                 let current_data = structuredClone(this.$kytos.toRaw(this.content))
                 for (const tableColumn of this.EVCTextFilter) {
@@ -206,12 +216,14 @@
                 return current_data
             }
         },
+        //Extracts data from localStorage (if available) when first mounted.
         mounted() {
             // Make the panel fill the screen except the left menu width
             if (JSON.parse(localStorage.getItem('telemetry_int/k-info-panel/show_telemetry_int_data/EVCTextFilter'))) {
                 this.EVCTextFilter = JSON.parse(localStorage.getItem('telemetry_int/k-info-panel/show_telemetry_int_data/EVCTextFilter'));
             }
         },
+        //Watches to see if data is changed to then store it within localStorage.
         watch: {
             EVCTextFilter: {
                 handler: function() {

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -243,7 +243,7 @@
       padding: 0.5em 0 1em 0.3em;
       font-size: 0.8em;
       overflow-x: hidden;
-      overflow-y: visible;
+      overflow-y: auto;
     }
     .INT_table table{
       display: table;

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -22,16 +22,16 @@
                             <thead>
                                 <tr>
                                     <th class="sortable-column" rowspan="2" colspan="1"></th>
-                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('ID')">ID &nbsp;{{sortIdentifier[0]}}</th>
-                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('NAME')">Name &nbsp;{{sortIdentifier[1]}}</th>
-                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('ACTIVE')">Active &nbsp;{{sortIdentifier[2]}}</th>
+                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('id')">ID &nbsp;{{sortIdentifierList[0]}}</th>
+                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('name')">Name &nbsp;{{sortIdentifierList[1]}}</th>
+                                    <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('active')">Active &nbsp;{{sortIdentifierList[2]}}</th>
                                     <th rowspan="1" colspan="4">Telemetry</th>
                                 </tr>
                                 <tr>
-                                    <th class="sortable-column" @click="changeSortedColumn('ENABLED')">Enabled &nbsp;{{sortIdentifier[3]}}</th>
-                                    <th class="sortable-column" @click="changeSortedColumn('STATUS')">Status &nbsp;{{sortIdentifier[4]}}</th>
-                                    <th class="sortable-column" @click="changeSortedColumn('STATUS_REASON')">Status Reason &nbsp;{{sortIdentifier[5]}}</th>
-                                    <th class="sortable-column" @click="changeSortedColumn('STATUS_UPDATED_AT')">Status Updated At &nbsp;{{sortIdentifier[6]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('enabled')">Enabled &nbsp;{{sortIdentifierList[3]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('status')">Status &nbsp;{{sortIdentifierList[4]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('status_reason')">Status Reason &nbsp;{{sortIdentifierList[5]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('status_updated_at')">Status Updated At &nbsp;{{sortIdentifierList[6]}}</th>
                                 </tr>
                                 <tr>
                                     <th>
@@ -95,7 +95,9 @@
                 selectedEVCs: [],
                 forceOption: [],
                 sortedColumnName: ["", 0],
-                sortIdentifier: ["", "", "", "", "", "", ""]
+                sortIdentifier: {id: 0, name: 1, active: 2, enabled: 3, status: 4, status_reason: 5, status_updated_at: 6},
+                sortSymbols: ["▲", "▼"],
+                sortIdentifierList: ["", "", "", "", "", "", ""]
             }
         },
         methods: {
@@ -120,60 +122,11 @@
                 } else {
                     this.sortedColumnName = [name, 0]
                 }
-                switch(name) {
-                    case "ID":
-                        if (this.sortedColumnName[1]) {
-                            this.sortIdentifier = ["▼", "", "", "", "", "", ""]
-                        } else {
-                            this.sortIdentifier = ["▲", "", "", "", "", "", ""]
-                        }
-                        break;
-                    case "NAME":
-                        if (this.sortedColumnName[1]) {
-                            this.sortIdentifier = ["", "▼", "", "", "", "", ""]
-                        } else {
-                            this.sortIdentifier = ["", "▲", "", "", "", "", ""]
-                        }
-                        break;
-                    case "ACTIVE":
-                        if (this.sortedColumnName[1]) {
-                            this.sortIdentifier = ["", "", "▼", "", "", "", ""]
-                        } else {
-                            this.sortIdentifier = ["", "", "▲", "", "", "", ""]
-                        }
-                        break;
-                    case "ENABLED":
-                        if (this.sortedColumnName[1]) {
-                            this.sortIdentifier = ["", "", "", "▼", "", "", ""]
-                        } else {
-                            this.sortIdentifier = ["", "", "", "▲", "", "", ""]
-                        }
-                        break;
-                    case "STATUS":
-                        if (this.sortedColumnName[1]) {
-                            this.sortIdentifier = ["", "", "", "", "▼", "", ""]
-                        } else {
-                            this.sortIdentifier = ["", "", "", "", "▲", "", ""]
-                        }
-                        break;
-                    case "STATUS_REASON":
-                        if (this.sortedColumnName[1]) {
-                            this.sortIdentifier = ["", "", "", "", "", "▼", ""]
-                        } else {
-                            this.sortIdentifier = ["", "", "", "", "", "▲", ""]
-                        }
-                        break;
-                    case "STATUS_UPDATED_AT":
-                        if (this.sortedColumnName[1]) {
-                            this.sortIdentifier = ["", "", "", "", "", "", "▼"]
-                        } else {
-                            this.sortIdentifier = ["", "", "", "", "", "", "▲"]
-                        }
-                        break;
-                    default:
-                        this.sortIdentifier = ["", "", "", "", "", "", ""]
-                        break;
-                }
+                this.setSortedColumn()
+            },
+            setSortedColumn() {
+                this.sortIdentifierList = ["", "", "", "", "", "", ""]
+                this.sortIdentifierList[this.sortIdentifier[this.sortedColumnName[0]]] = this.sortSymbols[this.sortedColumnName[1]]
             },
             //API request to enable EVCs selected within UI
             enableSelectedEVCs() {
@@ -325,170 +278,28 @@
                         return true
                     })
                     current_data = filtered_data
-                }
-                //Sort by ascending or descending order
-                switch(this.sortedColumnName[0]) {
-                    case "ID":
-                        if(this.sortedColumnName[1]) {
-                            current_data.sort((a, b) => {
-                                if (a.id > b.id) {
-                                    return -1;
-                                }
-                                if (a.id < b.id) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        } else {
-                            current_data.sort((a, b) => {
-                                if (a.id < b.id) {
-                                    return -1;
-                                }
-                                if (a.id > b.id) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        }
-                        break;
-                    case "NAME":
-                        if(this.sortedColumnName[1]) {
-                            current_data.sort((a, b) => {
-                                if (a.name > b.name) {
-                                    return -1;
-                                }
-                                if (a.name < b.name) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        } else {
-                            current_data.sort((a, b) => {
-                                if (a.name < b.name) {
-                                    return -1;
-                                }
-                                if (a.name > b.name) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        }
-                        break;
-                    case "ACTIVE":
-                        if(this.sortedColumnName[1]) {
-                            current_data.sort((a, b) => {
-                                if (a.active > b.active) {
-                                    return -1;
-                                }
-                                if (a.active < b.active) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        } else {
-                            current_data.sort((a, b) => {
-                                if (a.active < b.active) {
-                                    return -1;
-                                }
-                                if (a.active > b.active) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        }
-                        break;
-                    case "ENABLED":
-                        if(this.sortedColumnName[1]) {
-                            current_data.sort((a, b) => {
-                                if (a.enabled > b.enabled) {
-                                    return -1;
-                                }
-                                if (a.enabled < b.enabled) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        } else {
-                            current_data.sort((a, b) => {
-                                if (a.enabled < b.enabled) {
-                                    return -1;
-                                }
-                                if (a.enabled > b.enabled) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        }
-                        break;
-                    case "STATUS":
-                        if(this.sortedColumnName[1]) {
-                            current_data.sort((a, b) => {
-                                if (a.status > b.status) {
-                                    return -1;
-                                }
-                                if (a.status < b.status) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        } else {
-                            current_data.sort((a, b) => {
-                                if (a.status < b.status) {
-                                    return -1;
-                                }
-                                if (a.status > b.status) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        }
-                        break;
-                    case "STATUS_REASON":
-                        if(this.sortedColumnName[1]) {
-                            current_data.sort((a, b) => {
-                                if (a.status_reason > b.status_reason) {
-                                    return -1;
-                                }
-                                if (a.status_reason < b.status_reason) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        } else {
-                            current_data.sort((a, b) => {
-                                if (a.status_reason < b.status_reason) {
-                                    return -1;
-                                }
-                                if (a.status_reason > b.status_reason) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        }
-                        break;
-                    case "STATUS_UPDATED_AT":
-                        if(this.sortedColumnName[1]) {
-                            current_data.sort((a, b) => {
-                                if (a.status_updated_at > b.status_updated_at) {
-                                    return -1;
-                                }
-                                if (a.status_updated_at < b.status_updated_at) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        } else {
-                            current_data.sort((a, b) => {
-                                if (a.status_updated_at < b.status_updated_at) {
-                                    return -1;
-                                }
-                                if (a.status_updated_at > b.status_updated_at) {
-                                    return 1;
-                                }
-                                return 0;
-                            });
-                        }
-                        break;
+                    //Sort by ascending or descending order
+                    if(this.sortedColumnName[1]) {
+                        current_data.sort((a, b) => {
+                            if (a[this.sortedColumnName[0]] > b[this.sortedColumnName[0]]) {
+                                return -1;
+                            }
+                            if (a[this.sortedColumnName[0]] < b[this.sortedColumnName[0]]) {
+                                return 1;
+                            }
+                            return 0;
+                        });
+                    } else {
+                        current_data.sort((a, b) => {
+                            if (a[this.sortedColumnName[0]] < b[this.sortedColumnName[0]]) {
+                                return -1;
+                            }
+                            if (a[this.sortedColumnName[0]] > b[this.sortedColumnName[0]]) {
+                                return 1;
+                            }
+                            return 0;
+                        });
+                    }
                 }
                 return current_data
             }

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -22,16 +22,16 @@
                             <thead>
                                 <tr>
                                     <th rowspan="2" colspan="1"></th>
-                                    <th rowspan="2" colspan="1">ID</th>
-                                    <th rowspan="2" colspan="1">Name</th>
-                                    <th rowspan="2" colspan="1">Active</th>
+                                    <th rowspan="2" colspan="1" @click="changeSortedColumn('ID')">ID</th>
+                                    <th rowspan="2" colspan="1" @click="changeSortedColumn('NAME')">Name</th>
+                                    <th rowspan="2" colspan="1" @click="changeSortedColumn('ACTIVE')">Active</th>
                                     <th rowspan="1" colspan="4">Telemetry</th>
                                 </tr>
                                 <tr>
-                                    <th>Enabled</th>
-                                    <th>Status</th>
-                                    <th>Status Reason</th>
-                                    <th>Status Updated At</th>
+                                    <th @click="changeSortedColumn('ENABLED')">Enabled</th>
+                                    <th @click="changeSortedColumn('STATUS')">Status</th>
+                                    <th @click="changeSortedColumn('STATUS_REASON')">Status Reason</th>
+                                    <th @click="changeSortedColumn('STATUS_UPDATED_AT')">Status Updated At</th>
                                 </tr>
                                 <tr>
                                     <th>
@@ -93,7 +93,8 @@
                     ["status_updated_at", ""]
                 ],
                 selectedEVCs: [],
-                forceOption: []
+                forceOption: [],
+                sortedColumnName: ["", 0]
             }
         },
         methods: {
@@ -101,8 +102,6 @@
             /**
              * @param {Object} data - The normal table row object containing:
              * @param {string} data.status - The status of the device the Object references.
-             * @param {string} data.status_reason - The status_reason of the device the Object references.
-             * @param {boolean} data.enabled - State of the device the Object references. Enabled or Disabled.
              * @returns {string} Returns a string that acts as the class for current HTML element.
              * @description Sets color for current status table cell.
              */
@@ -112,6 +111,15 @@
                     case (data.status == "DOWN"):
                         return "red";
                 }
+            },
+            //Changes the current column to sort the table by
+            changeSortedColumn(name) {
+                if (this.sortedColumnName[0] == name && this.sortedColumnName[1] == 0) {
+                    this.sortedColumnName[1] = 1
+                } else {
+                    this.sortedColumnName = [name, 0]
+                }
+                console.log(this.sortedColumnName)
             },
             //API request to enable EVCs selected within UI
             enableSelectedEVCs() {
@@ -199,19 +207,186 @@
             }
         },
         computed: {
-            //Filters the content obtained via the prop from main.kytos based on the textFilters/searchColumns
+            //Filters the content obtained via the prop from main.kytos based on the textFilters/searchColumns and then the column ordering
             filtered_EVCData: function() {
-                let current_data = structuredClone(this.$kytos.toRaw(this.content))
-                for (const tableColumn of this.EVCTextFilter) {
-                    if (tableColumn[1] != "") {
-                        for (const EVC in current_data) {
-                            var separatedFilter = tableColumn[1].toString()
-                            var separatedProperty = current_data[EVC][tableColumn[0]].toString()
+                let current_data = this.$kytos.toRaw(this.content)
+                //Filter based on the search columns
+                if (current_data) {
+                    let filtered_data = current_data.filter((EVC) => {
+                        for (const tableColumn of this.EVCTextFilter) {
+                            let separatedFilter = tableColumn[1].toString()
+                            let separatedProperty = EVC[tableColumn[0]].toString()
                             if (!(separatedProperty.includes(separatedFilter) || separatedFilter.includes(separatedProperty))) {
-                                delete current_data[EVC]
+                                return false
                             }
                         }
-                    }
+                        return true
+                    })
+                    current_data = filtered_data
+                }
+                //Sort by ascending or descending order
+                switch(this.sortedColumnName[0]) {
+                    case "ID":
+                        if(this.sortedColumnName[1]) {
+                            current_data.sort((a, b) => {
+                                if (a.id > b.id) {
+                                    return -1;
+                                }
+                                if (a.id < b.id) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        } else {
+                            current_data.sort((a, b) => {
+                                if (a.id < b.id) {
+                                    return -1;
+                                }
+                                if (a.id > b.id) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        }
+                        break;
+                    case "NAME":
+                        if(this.sortedColumnName[1]) {
+                            current_data.sort((a, b) => {
+                                if (a.name > b.name) {
+                                    return -1;
+                                }
+                                if (a.name < b.name) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        } else {
+                            current_data.sort((a, b) => {
+                                if (a.name < b.name) {
+                                    return -1;
+                                }
+                                if (a.name > b.name) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        }
+                        break;
+                    case "ACTIVE":
+                        if(this.sortedColumnName[1]) {
+                            current_data.sort((a, b) => {
+                                if (a.active > b.active) {
+                                    return -1;
+                                }
+                                if (a.active < b.active) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        } else {
+                            current_data.sort((a, b) => {
+                                if (a.active < b.active) {
+                                    return -1;
+                                }
+                                if (a.active > b.active) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        }
+                        break;
+                    case "ENABLED":
+                        if(this.sortedColumnName[1]) {
+                            current_data.sort((a, b) => {
+                                if (a.enabled > b.enabled) {
+                                    return -1;
+                                }
+                                if (a.enabled < b.enabled) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        } else {
+                            current_data.sort((a, b) => {
+                                if (a.enabled < b.enabled) {
+                                    return -1;
+                                }
+                                if (a.enabled > b.enabled) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        }
+                        break;
+                    case "STATUS":
+                        if(this.sortedColumnName[1]) {
+                            current_data.sort((a, b) => {
+                                if (a.status > b.status) {
+                                    return -1;
+                                }
+                                if (a.status < b.status) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        } else {
+                            current_data.sort((a, b) => {
+                                if (a.status < b.status) {
+                                    return -1;
+                                }
+                                if (a.status > b.status) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        }
+                        break;
+                    case "STATUS_REASON":
+                        if(this.sortedColumnName[1]) {
+                            current_data.sort((a, b) => {
+                                if (a.status_reason > b.status_reason) {
+                                    return -1;
+                                }
+                                if (a.status_reason < b.status_reason) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        } else {
+                            current_data.sort((a, b) => {
+                                if (a.status_reason < b.status_reason) {
+                                    return -1;
+                                }
+                                if (a.status_reason > b.status_reason) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        }
+                        break;
+                    case "STATUS_UPDATED_AT":
+                        if(this.sortedColumnName[1]) {
+                            current_data.sort((a, b) => {
+                                if (a.status_updated_at > b.status_updated_at) {
+                                    return -1;
+                                }
+                                if (a.status_updated_at < b.status_updated_at) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        } else {
+                            current_data.sort((a, b) => {
+                                if (a.status_updated_at < b.status_updated_at) {
+                                    return -1;
+                                }
+                                if (a.status_updated_at > b.status_updated_at) {
+                                    return 1;
+                                }
+                                return 0;
+                            });
+                        }
+                        break;
                 }
                 return current_data
             }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -24,11 +24,10 @@ module.exports = {
                             url: this.$kytos_server_api + "kytos/mef_eline/v2/evc/",
                             async: true});
             request.done(function(data) {
-                console.log(data)
-                this.extract_TelemetryINTData(data)
+                self.extract_TelemetryINTData(data)
+                self.display_InfoPanel()
             });
             request.fail(function(data) {
-                console.log("failure")
                 let notification = {
                     icon: 'cog',
                     title: 'Could not retrieve EVCs',
@@ -39,7 +38,22 @@ module.exports = {
         },
         extract_TelemetryINTData(EVC_Data) {
             for (let EVC in EVC_Data) {
-                console.log(EVC)
+                this.telemetryINT_Data[EVC] = {}
+                this.telemetryINT_Data[EVC]["active"] = EVC_Data[EVC].active
+                this.telemetryINT_Data[EVC]["id"] = EVC_Data[EVC].id
+                this.telemetryINT_Data[EVC]["name"] = EVC_Data[EVC].name
+                if (EVC_Data[EVC].metadata?.telemetry) {
+                    this.telemetryINT_Data[EVC]["enabled"] = EVC_Data[EVC].metadata.telemetry.enabled
+                    this.telemetryINT_Data[EVC]["status"] = EVC_Data[EVC].metadata.telemetry.status
+                    this.telemetryINT_Data[EVC]["status_reason"] = this.splitStatusReasons(EVC_Data[EVC].metadata.telemetry.status_reason)
+                    this.telemetryINT_Data[EVC]["status_updated_at"] = EVC_Data[EVC].metadata.telemetry.status_updated_at
+                } else {
+                    this.telemetryINT_Data[EVC]["enabled"] = "N/A"
+                    this.telemetryINT_Data[EVC]["status"] = "N/A"
+                    this.telemetryINT_Data[EVC]["status_reason"] = "N/A"
+                    this.telemetryINT_Data[EVC]["status_updated_at"] = "N/A"
+                }
+
             }
         },
         display_InfoPanel() {
@@ -50,8 +64,12 @@ module.exports = {
                           "title": "View Telemetry INT Data",
                           "subtitle": "by kytos/telemetry_int"
                           }
-            this.$kytos.$emit("showInfoPanel", content)
+            this.$kytos.eventBus.$emit("showInfoPanel", content)
         },
+        //Formats status reason data for table
+        splitStatusReasons(statusReasons) {
+            return statusReasons.toString()
+        }
     },
     computed: {
 

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -37,6 +37,7 @@ module.exports = {
             });
         },
         extract_TelemetryINTData(EVC_Data) {
+            this.telemetryINT_Data = {}
             for (let EVC in EVC_Data) {
                 this.telemetryINT_Data[EVC] = {}
                 this.telemetryINT_Data[EVC]["active"] = EVC_Data[EVC].active

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -13,7 +13,7 @@
 module.exports = {
     data: function() {
         return {
-            telemetryINT_Data: {},
+            telemetryINT_Data: [],
         }
     },
     methods: {
@@ -43,23 +43,24 @@ module.exports = {
          * @description Extracts only the required information for the telemetry_int table from the mef_eline EVC data.
          */
         extract_TelemetryINTData(EVC_Data) {
-            this.telemetryINT_Data = {}
+            this.telemetryINT_Data = []
             for (let EVC in EVC_Data) {
-                this.telemetryINT_Data[EVC] = {}
-                this.telemetryINT_Data[EVC]["active"] = EVC_Data[EVC].active
-                this.telemetryINT_Data[EVC]["id"] = EVC_Data[EVC].id
-                this.telemetryINT_Data[EVC]["name"] = EVC_Data[EVC].name
+                let EVC_Obj = {}
+                EVC_Obj["active"] = EVC_Data[EVC].active
+                EVC_Obj["id"] = EVC_Data[EVC].id
+                EVC_Obj["name"] = EVC_Data[EVC].name
                 if (EVC_Data[EVC].metadata?.telemetry) {
-                    this.telemetryINT_Data[EVC]["enabled"] = EVC_Data[EVC].metadata.telemetry.enabled
-                    this.telemetryINT_Data[EVC]["status"] = EVC_Data[EVC].metadata.telemetry.status
-                    this.telemetryINT_Data[EVC]["status_reason"] = this.splitStatusReasons(EVC_Data[EVC].metadata.telemetry.status_reason)
-                    this.telemetryINT_Data[EVC]["status_updated_at"] = EVC_Data[EVC].metadata.telemetry.status_updated_at
+                    EVC_Obj["enabled"] = EVC_Data[EVC].metadata.telemetry.enabled.toString()
+                    EVC_Obj["status"] = EVC_Data[EVC].metadata.telemetry.status
+                    EVC_Obj["status_reason"] = this.splitStatusReasons(EVC_Data[EVC].metadata.telemetry.status_reason)
+                    EVC_Obj["status_updated_at"] = EVC_Data[EVC].metadata.telemetry.status_updated_at
                 } else {
-                    this.telemetryINT_Data[EVC]["enabled"] = "N/A"
-                    this.telemetryINT_Data[EVC]["status"] = "N/A"
-                    this.telemetryINT_Data[EVC]["status_reason"] = "N/A"
-                    this.telemetryINT_Data[EVC]["status_updated_at"] = "N/A"
+                    EVC_Obj["enabled"] = "N/A"
+                    EVC_Obj["status"] = "N/A"
+                    EVC_Obj["status_reason"] = "N/A"
+                    EVC_Obj["status_updated_at"] = "N/A"
                 }
+                this.telemetryINT_Data.push(EVC_Obj)
             }
         },
         /**

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -1,0 +1,60 @@
+<template>
+    <k-toolbar-item icon="chart-line" tooltip="Telemetry INT">
+        <k-accordion>
+            <k-accordion-item title="List EVCs">
+                <k-button icon="plug" title="List Installed EVCs" @click="get_EVCs">
+                </k-button>
+            </k-accordion-item>
+        </k-accordion>
+    </k-toolbar-item>
+</template>
+<script>
+module.exports = {
+    data: function() {
+        return {
+            telemetryINT_Data: {},
+        }
+    },
+    methods: {
+        get_EVCs() {
+            var self = this
+            let request = $.ajax({
+                            type:"GET",
+                            dataType: "json",
+                            url: this.$kytos_server_api + "kytos/mef_eline/v2/evc/",
+                            async: true});
+            request.done(function(data) {
+                console.log(data)
+                this.extract_TelemetryINTData(data)
+            });
+            request.fail(function(data) {
+                console.log("failure")
+                let notification = {
+                    icon: 'cog',
+                    title: 'Could not retrieve EVCs',
+                    description: data.status.toString()
+                }
+                self.$kytos.eventBus.$emit("setNotification", notification)
+            });
+        },
+        extract_TelemetryINTData(EVC_Data) {
+            for (let EVC in EVC_Data) {
+                console.log(EVC)
+            }
+        },
+        display_InfoPanel() {
+            var content = {
+                          "component": 'kytos-telemetry_int-k-info-panel-show_telemetry_int_data',
+                          "content": this.telemetryINT_Data,
+                          "icon": "info-circle",
+                          "title": "View Telemetry INT Data",
+                          "subtitle": "by kytos/telemetry_int"
+                          }
+            this.$kytos.$emit("showInfoPanel", content)
+        },
+    },
+    computed: {
+
+    }
+}
+</script>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -31,7 +31,7 @@ module.exports = {
                 let notification = {
                     icon: 'cog',
                     title: 'Could not retrieve EVCs',
-                    description: data.status.toString()
+                    description: data.status.toString() + ": " + data.responseJSON.description
                 }
                 self.$kytos.eventBus.$emit("setNotification", notification)
             });

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -1,6 +1,7 @@
 <template>
     <k-toolbar-item icon="chart-line" tooltip="Telemetry INT">
         <k-accordion>
+            <!-- Button for displaying info panel with telemetry_int data -->
             <k-accordion-item title="List EVCs">
                 <k-button icon="plug" title="List Installed EVCs" @click="get_EVCs">
                 </k-button>
@@ -16,6 +17,7 @@ module.exports = {
         }
     },
     methods: {
+        //API request for EVC data
         get_EVCs() {
             var self = this
             let request = $.ajax({
@@ -36,6 +38,10 @@ module.exports = {
                 self.$kytos.eventBus.$emit("setNotification", notification)
             });
         },
+        /**
+         * @param {Object} EVC_Data - The EVC data from mef_eline.
+         * @description Extracts only the required information for the telemetry_int table from the mef_eline EVC data.
+         */
         extract_TelemetryINTData(EVC_Data) {
             this.telemetryINT_Data = {}
             for (let EVC in EVC_Data) {
@@ -56,6 +62,11 @@ module.exports = {
                 }
             }
         },
+        /**
+         * @event showInfoPanel
+         * @param {Object} telemetryINT_Data - Data specific to telemetry_int extracted from mef_eline EVC data.
+         * @description Displays info panel when the "List Installed EVCs" button is clicked.
+         */
         display_InfoPanel() {
             var content = {
                           "component": 'kytos-telemetry_int-k-info-panel-show_telemetry_int_data',

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -53,7 +53,6 @@ module.exports = {
                     this.telemetryINT_Data[EVC]["status_reason"] = "N/A"
                     this.telemetryINT_Data[EVC]["status_updated_at"] = "N/A"
                 }
-
             }
         },
         display_InfoPanel() {
@@ -70,9 +69,6 @@ module.exports = {
         splitStatusReasons(statusReasons) {
             return statusReasons.toString()
         }
-    },
-    computed: {
-
     }
 }
 </script>


### PR DESCRIPTION
Closes #92
Closes #93 

### Summary
The UI for the telemetry_int napp was added. It allows the user to view a list of available EVCs and their corresponding INT data. You can also enable, disable, and redeploy INT on a set of chosen EVCs via the UI. 

You can filter the EVCs based on specific characteristics with the corresponding search columns. Data is saved within local storage to maintain the state of the search columns between each session.

An image below of the telemetry_int UI can be seen:

<img width="1280" alt="image" src="https://github.com/kytos-ng/telemetry_int/assets/142065709/0d331682-7032-469b-9003-3b32e2616eb9">


### Local Tests
A combination of all parameters were used all at once to ensure functionality.
INT was enabled, disabled, and redeployed on a single EVC.
To test the new local storage functionality the page was refreshed and the data stayed the same.
