### PR TITLE
feat: validate shared proxy port

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Added
 Changed
 =======
 - Only raise ``FlowsNotFound`` when an EVC is active and flows aren't found. Update status and status_reason accordingly too when installing flows.
+- Validate to support only a single proxy port per UNI for now.
 
 Fixed
 =====

--- a/exceptions.py
+++ b/exceptions.py
@@ -53,6 +53,11 @@ class ProxyPortSameSourceIntraEVC(ProxyPortError):
     """
 
 
+class ProxyPortShared(ProxyPortError):
+    """ProxyPortShared. A shared proxy port isn't supported for now.
+    Each uni should have its own proxy port"""
+
+
 class EVCHasNoINT(EVCError):
     """Exception in case the EVC doesn't have INT enabled."""
 

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from .exceptions import (
     FlowsNotFound,
     ProxyPortNotFound,
     ProxyPortSameSourceIntraEVC,
+    ProxyPortShared,
     ProxyPortStatusNotUP,
     UnrecoverableError,
 )
@@ -115,7 +116,12 @@ class Main(KytosNApp):
             await self.int_manager.enable_int(evcs, force)
         except (EVCNotFound, FlowsNotFound, ProxyPortNotFound) as exc:
             raise HTTPException(404, detail=str(exc))
-        except (EVCHasINT, ProxyPortStatusNotUP, ProxyPortSameSourceIntraEVC) as exc:
+        except (
+            EVCHasINT,
+            ProxyPortStatusNotUP,
+            ProxyPortSameSourceIntraEVC,
+            ProxyPortShared,
+        ) as exc:
             raise HTTPException(409, detail=str(exc))
         except RetryError as exc:
             exc_error = str(exc.last_attempt.exception())
@@ -232,7 +238,7 @@ class Main(KytosNApp):
             await self.int_manager.redeploy_int(evcs)
         except (EVCNotFound, FlowsNotFound, ProxyPortNotFound) as exc:
             raise HTTPException(404, detail=str(exc))
-        except (EVCHasNoINT, ProxyPortSameSourceIntraEVC) as exc:
+        except (EVCHasNoINT, ProxyPortSameSourceIntraEVC, ProxyPortShared) as exc:
             raise HTTPException(409, detail=str(exc))
         except RetryError as exc:
             exc_error = str(exc.last_attempt.exception())

--- a/managers/int.py
+++ b/managers/int.py
@@ -280,12 +280,22 @@ class INTManager:
             try:
                 await self.enable_int(affected_evcs, force=True)
             except (ProxyPortSameSourceIntraEVC, ProxyPortShared) as exc:
-                # TODO update metdata
                 msg = (
                     f"Validation error when updating interface {intf}"
                     f" EVC ids: {list(affected_evcs)}, exception {str(exc)}"
                 )
                 log.error(msg)
+                metadata = {
+                    "telemetry": {
+                        "enabled": False,
+                        "status": "DOWN",
+                        "status_reason": ["proxy_port_shared"],
+                        "status_updated_at": datetime.utcnow().strftime(
+                            "%Y-%m-%dT%H:%M:%S"
+                        ),
+                    }
+                }
+                api.add_evcs_metadata(affected_evcs, metadata)
 
     async def disable_int(
         self, evcs: dict[str, dict], force=False, reason="disabled"

--- a/managers/int.py
+++ b/managers/int.py
@@ -295,7 +295,7 @@ class INTManager:
                         ),
                     }
                 }
-                api.add_evcs_metadata(affected_evcs, metadata)
+                await api.add_evcs_metadata(affected_evcs, metadata)
 
     async def disable_int(
         self, evcs: dict[str, dict], force=False, reason="disabled"
@@ -542,7 +542,7 @@ class INTManager:
                         f"UNI {found} would use {pp}"
                     )
                     raise ProxyPortShared(evc["id"], msg)
-                seen_src_unis[pp_a.source.id] = uni_id
+                seen_src_unis[pp.source.id] = uni_id
 
     async def handle_failover_flows(
         self, evcs_content: dict[str, dict], event_name: str

--- a/settings.py
+++ b/settings.py
@@ -13,12 +13,12 @@ TABLE_GROUP_ALLOWED = {"evpl", "epl"}
 
 # BATCH_INTERVAL: time interval between batch requests that will be sent to
 # flow_manager (in seconds) - zero enable sending all the requests in a row
-BATCH_INTERVAL = 0.2
+BATCH_INTERVAL = 0.5
 
 # BATCH_SIZE: size of a batch request that will be sent to flow_manager, in
 # number of FlowMod requests. Use 0 (zero) to disable BATCH mode, i.e. sends
 # everything at a glance
-BATCH_SIZE = 200
+BATCH_SIZE = 50
 
 # Fallback to mef_eline by removing INT flows if an external loop goes down. If
 # the loop goes UP again and the EVC is active, it'll install INT flows

--- a/settings.py
+++ b/settings.py
@@ -13,12 +13,12 @@ TABLE_GROUP_ALLOWED = {"evpl", "epl"}
 
 # BATCH_INTERVAL: time interval between batch requests that will be sent to
 # flow_manager (in seconds) - zero enable sending all the requests in a row
-BATCH_INTERVAL = 0.5
+BATCH_INTERVAL = 0.2
 
 # BATCH_SIZE: size of a batch request that will be sent to flow_manager, in
 # number of FlowMod requests. Use 0 (zero) to disable BATCH mode, i.e. sends
 # everything at a glance
-BATCH_SIZE = 50
+BATCH_SIZE = 200
 
 # Fallback to mef_eline by removing INT flows if an external loop goes down. If
 # the loop goes UP again and the EVC is active, it'll install INT flows

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -324,6 +324,37 @@ class TestINTManager:
         assert not int_manager.disable_int.call_count
         assert not int_manager.enable_int.call_count
 
+    async def test_handle_pp_metadata_added_exc_port_shared(self, monkeypatch):
+        """Test handle_pp_metadata_added exception port shared."""
+        log_mock = MagicMock()
+        monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.log", log_mock)
+        int_manager = INTManager(MagicMock())
+        api_mock, intf_mock, pp_mock = AsyncMock(), MagicMock(), MagicMock()
+        intf_mock.id = "some_intf_id"
+        source_id, source_port = "some_source_id", 2
+        intf_mock.metadata = {"proxy_port": source_port}
+        evc_id = "3766c105686748"
+        int_manager.unis_src[intf_mock.id] = source_id
+        int_manager.srcs_pp[source_id] = pp_mock
+        pp_mock.evc_ids = {evc_id}
+
+        assert "proxy_port" in intf_mock.metadata
+        monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
+        api_mock.get_evcs.return_value = {evc_id: {}}
+        int_manager.disable_int = AsyncMock()
+        int_manager.enable_int = AsyncMock()
+        int_manager.enable_int.side_effect = ProxyPortShared(evc_id, "shared")
+
+        await int_manager.handle_pp_metadata_added(intf_mock)
+        assert api_mock.get_evcs.call_count == 1
+        assert api_mock.get_evcs.call_count == 1
+        assert api_mock.get_evcs.call_args[1] == {"metadata.telemetry.enabled": "true"}
+        assert int_manager.disable_int.call_count == 1
+        assert int_manager.enable_int.call_count == 1
+
+        assert api_mock.add_evcs_metadata.call_count == 1
+        assert log_mock.error.call_count == 1
+
     async def test_disable_int_metadata(self, monkeypatch) -> None:
         """Test disable INT metadata args."""
         controller = MagicMock()


### PR DESCRIPTION
Closes #110 

### Summary

See updated changelog file 

Configuration for metadata will be covered on issue #112 

### Local Tests

I've explored four test cases:
1) Tried to enable in the same request with a shared proxy port, returned validation error


![20240726_122852](https://github.com/user-attachments/assets/5b41624f-4b05-4005-abc9-bc2e47ed905c)

2) Tried to enable in different requests with a shared proxy port, returned validation error

![20240726_122908](https://github.com/user-attachments/assets/997d1f60-d634-4192-89b6-523ab2bf6402)


3) I updated `proxy_port` metadata via `topology` and it fixed it automatically by enabling it again now that the meadata wasn't conflicting

![20240726_122951](https://github.com/user-attachments/assets/5310911a-391d-4525-b549-cf685a48d794)


3) I updated `proxy_port` metadata to be conflicting again, and it logged the error and also updated metadata with status `["proxy_port_shared"]`.

![20240726_123021](https://github.com/user-attachments/assets/95f33419-fb96-410f-9729-352717eb401f)

```
2024-07-26 12:30:01,883 - INFO [uvicorn.access] (MainThread) 127.0.0.1:47712 - "POST /api/kytos/mef_eline/v2/evc/metadata HTTP/1.1" 201
2024-07-26 12:30:01,885 - ERROR [kytos.napps.kytos/telemetry_int] (MainThread) Validation error when updating interface Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01')) EVC id
s: ['9327d5e0b1444a'], exception EVC 9327d5e0b1444a UNI 00:00:00:00:00:00:00:01:2 must use another dedicated proxy port. UNI 00:00:00:00:00:00:00:01:1 is using ProxyPort(Interface('s1-e
th5', 5, Switch('00:00:00:00:00:00:00:01')), Interface('s1-eth6', 6, Switch('00:00:00:00:00:00:00:01')), EntityStatus.UP)
```

### End-to-End Tests

N/A
