### PR TITLE
fix: optimized away redudant push_int flows when handling failover events

### DIFF
--- a/managers/int.py
+++ b/managers/int.py
@@ -627,9 +627,20 @@ class INTManager:
             log.info(
                 f"Handling {event_name} flows install on EVC ids: {to_install.keys()}"
             )
-            await self._install_int_flows(
-                self.flow_builder.build_int_flows(to_install, new_flows)
-            )
+            built_flows = self.flow_builder.build_int_flows(to_install, new_flows)
+            built_flows = {
+                cookie: [
+                    flow
+                    for flow in flows
+                    if not utils.has_instruction_and_action_type(
+                        flow.get("flow", {}).get("instructions", []),
+                        "apply_actions",
+                        "push_int",
+                    )
+                ]
+                for cookie, flows in built_flows.items()
+            }
+            await self._install_int_flows(built_flows)
 
     def _validate_map_enable_evcs(
         self,

--- a/tests/unit/test_flow_builder_failover.py
+++ b/tests/unit/test_flow_builder_failover.py
@@ -156,52 +156,6 @@ async def test_handle_failover_link_down() -> None:
         "12307967605643950656": [
             {
                 "flow": {
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 100,
-                        "dl_type": 2048,
-                        "nw_proto": 6,
-                    },
-                    "cookie": 12163852417568094784,
-                    "owner": "telemetry_int",
-                    "table_group": "evpl",
-                    "table_id": 0,
-                    "priority": 20100,
-                    "instructions": [
-                        {
-                            "instruction_type": "apply_actions",
-                            "actions": [{"action_type": "push_int"}],
-                        },
-                        {"instruction_type": "goto_table", "table_id": 2},
-                    ],
-                },
-                "switch": "00:00:00:00:00:00:00:01",
-            },
-            {
-                "flow": {
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 100,
-                        "dl_type": 2048,
-                        "nw_proto": 17,
-                    },
-                    "cookie": 12163852417568094784,
-                    "owner": "telemetry_int",
-                    "table_group": "evpl",
-                    "table_id": 0,
-                    "priority": 20100,
-                    "instructions": [
-                        {
-                            "instruction_type": "apply_actions",
-                            "actions": [{"action_type": "push_int"}],
-                        },
-                        {"instruction_type": "goto_table", "table_id": 2},
-                    ],
-                },
-                "switch": "00:00:00:00:00:00:00:01",
-            },
-            {
-                "flow": {
                     "match": {"in_port": 1, "dl_vlan": 100},
                     "cookie": 12163852417568094784,
                     "owner": "telemetry_int",
@@ -221,52 +175,6 @@ async def test_handle_failover_link_down() -> None:
                     ],
                 },
                 "switch": "00:00:00:00:00:00:00:01",
-            },
-            {
-                "flow": {
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 100,
-                        "dl_type": 2048,
-                        "nw_proto": 6,
-                    },
-                    "cookie": 12163852417568094784,
-                    "owner": "telemetry_int",
-                    "table_group": "evpl",
-                    "table_id": 0,
-                    "priority": 20100,
-                    "instructions": [
-                        {
-                            "instruction_type": "apply_actions",
-                            "actions": [{"action_type": "push_int"}],
-                        },
-                        {"instruction_type": "goto_table", "table_id": 2},
-                    ],
-                },
-                "switch": "00:00:00:00:00:00:00:03",
-            },
-            {
-                "flow": {
-                    "match": {
-                        "in_port": 1,
-                        "dl_vlan": 100,
-                        "dl_type": 2048,
-                        "nw_proto": 17,
-                    },
-                    "cookie": 12163852417568094784,
-                    "owner": "telemetry_int",
-                    "table_group": "evpl",
-                    "table_id": 0,
-                    "priority": 20100,
-                    "instructions": [
-                        {
-                            "instruction_type": "apply_actions",
-                            "actions": [{"action_type": "push_int"}],
-                        },
-                        {"instruction_type": "goto_table", "table_id": 2},
-                    ],
-                },
-                "switch": "00:00:00:00:00:00:00:03",
             },
             {
                 "flow": {

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -164,6 +164,55 @@ def test_add_to_apply_actions() -> None:
     assert instructions[0]["actions"][0] == new_instruction
 
 
+@pytest.mark.parametrize(
+    "instructions,instruction_type,action_type,expected",
+    [
+        (
+            [
+                {
+                    "instruction_type": "apply_actions",
+                    "actions": [{"action_type": "push_int"}],
+                },
+                {"instruction_type": "goto_table", "table_id": 2},
+            ],
+            "apply_actions",
+            "push_int",
+            True,
+        ),
+        (
+            [
+                {"instruction_type": "goto_table", "table_id": 2},
+            ],
+            "apply_actions",
+            "push_int",
+            False,
+        ),
+        (
+            [
+                {
+                    "instruction_type": "apply_actions",
+                    "actions": [{"action_type": "push_int"}],
+                },
+                {"instruction_type": "goto_table", "table_id": 2},
+            ],
+            "apply_actions",
+            "pop_int",
+            False,
+        ),
+    ],
+)
+def test_has_instruction_and_action_type(
+    instructions, instruction_type, action_type, expected
+) -> None:
+    """Test add to apply actions."""
+    assert (
+        utils.has_instruction_and_action_type(
+            instructions, instruction_type, action_type
+        )
+        == expected
+    )
+
+
 def test_set_owner() -> None:
     """Test set_owner."""
     flow = {

--- a/utils.py
+++ b/utils.py
@@ -59,6 +59,22 @@ def add_to_apply_actions(
     return instructions
 
 
+def has_instruction_and_action_type(
+    instructions: list[dict], instruction_type: str, action_type: str
+) -> bool:
+    """Check if any of the instructions has a given type and action type."""
+    for instruction in instructions:
+        if (
+            instruction["instruction_type"] != instruction_type
+            or "actions" not in instruction
+        ):
+            continue
+        for action in instruction["actions"]:
+            if "action_type" in action and action["action_type"] == action_type:
+                return True
+    return False
+
+
 def get_cookie(evc_id: str, cookie_prefix: int) -> int:
     """Return the cookie integer from evc id.
 


### PR DESCRIPTION
Closes #119 

### Summary

- Optimized away redudant `push_int` flows when handling failover events.. No need for changelog to be updated since it's an optimization on code that hasn't been released yet. 

### Local Tests

- Confirmed that only a single INT flow was generated per mef_eline ingress flow:

```
2024-07-30 10:01:03,889 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_5) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: False, n_flows 1  flows[0, 1]: [{'match': {'in_port': 15, 'dl_vlan': 2222}, 'cookie': 12293275523393756481, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1
}, {'action_type': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-07-30 10:01:03,896 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_2) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: False, n_flows 1  flows[0, 1]: [{'match': {'in_port': 22, 'dl_vlan': 2222}, 'cookie': 12293275523393756481, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1
}, {'action_type': 'output', 'port': 5}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-07-30 10:01:03,900 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: True, n_flows 1  flows
[0, 1]: [{'match': {'in_port': 15, 'dl_vlan': 2222}, 'cookie': 12149160335317900609, 'owner': 'telemetry_int', 'table_group': 'evpl', 'table_id': 2, 'priority': 20000, 'instructions': [{
'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 2}]}]}]
2024-07-30 10:01:03,907 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: True, n_flows 1  flows
[0, 1]: [{'match': {'in_port': 22, 'dl_vlan': 2222}, 'cookie': 12149160335317900609, 'owner': 'telemetry_int', 'table_group': 'evpl', 'table_id': 2, 'priority': 20000, 'instructions': [{
'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1}, {'action_type': 'output', 'port': 5}]}]}]
```

- Tested a `failover_link_down` event with 101 INT EVCs on INT lab, it performed very similar to `mef_eline`, resulted in 1045 TCP retransmissions in the data plane and overall 9.3 Gbits/sec during the test:


```
root@int02:/home/amlight# iperf3 -c 10.22.22.3 -i 1 -t 60 -b 10G
Connecting to host 10.22.22.3, port 5201
[  4] local 10.22.22.2 port 59092 connected to 10.22.22.3 port 5201
[ ID] Interval           Transfer     Bandwidth       Retr  Cwnd
[  4]   0.00-1.00   sec  1.02 GBytes  8.72 Gbits/sec  319   1.86 MBytes       
[  4]   1.00-2.00   sec  1.11 GBytes  9.56 Gbits/sec    0   1.86 MBytes       
[  4]   2.00-3.00   sec  1.11 GBytes  9.56 Gbits/sec    0   1.86 MBytes       
[  4]   3.00-4.00   sec  1.11 GBytes  9.56 Gbits/sec    0   1.86 MBytes       
[  4]   4.00-5.00   sec  1.11 GBytes  9.56 Gbits/sec    0   1.86 MBytes       
[  4]   5.00-6.00   sec   416 MBytes  3.49 Gbits/sec   57   1.41 KBytes       
[  4]   6.00-7.00   sec   148 MBytes  1.24 Gbits/sec  630    510 KBytes       
[  4]   7.00-8.00   sec  1.11 GBytes  9.56 Gbits/sec    0    551 KBytes       
[  4]   8.00-9.00   sec  1.11 GBytes  9.56 Gbits/sec    0    574 KBytes       
[  4]   9.00-10.00  sec  1.11 GBytes  9.56 Gbits/sec    0    574 KBytes       
[  4]  10.00-11.00  sec  1.11 GBytes  9.53 Gbits/sec    0    807 KBytes       
[  4]  11.00-12.00  sec  1.11 GBytes  9.55 Gbits/sec    0    871 KBytes       
[  4]  12.00-13.00  sec  1.11 GBytes  9.56 Gbits/sec    0    871 KBytes       
[  4]  13.00-14.00  sec  1.11 GBytes  9.53 Gbits/sec    5    471 KBytes       
[  4]  14.00-15.00  sec  1.11 GBytes  9.54 Gbits/sec    0    642 KBytes       
[  4]  15.00-16.00  sec  1.11 GBytes  9.54 Gbits/sec    0    706 KBytes       
[  4]  16.00-17.00  sec  1.11 GBytes  9.51 Gbits/sec    0    810 KBytes       
[  4]  17.00-18.00  sec  1.11 GBytes  9.56 Gbits/sec    0    810 KBytes       
[  4]  18.00-19.00  sec  1.11 GBytes  9.56 Gbits/sec    0    810 KBytes       
[  4]  19.00-20.00  sec  1.11 GBytes  9.56 Gbits/sec    0    810 KBytes       
[  4]  20.00-21.00  sec  1.11 GBytes  9.49 Gbits/sec    0    847 KBytes       
[  4]  21.00-22.00  sec  1.11 GBytes  9.55 Gbits/sec    0    880 KBytes       
[  4]  22.00-23.00  sec  1.11 GBytes  9.56 Gbits/sec    0    884 KBytes       
[  4]  23.00-24.00  sec  1.11 GBytes  9.56 Gbits/sec    0    884 KBytes       
[  4]  24.00-25.00  sec  1.11 GBytes  9.56 Gbits/sec    0    891 KBytes       
[  4]  25.00-26.00  sec  1.11 GBytes  9.56 Gbits/sec    0    891 KBytes       
[  4]  26.00-27.00  sec  1.11 GBytes  9.56 Gbits/sec    0    936 KBytes       
[  4]  27.00-28.00  sec  1.11 GBytes  9.56 Gbits/sec    0    946 KBytes       
[  4]  28.00-29.00  sec  1.11 GBytes  9.56 Gbits/sec    0    946 KBytes       
[  4]  29.00-30.00  sec  1.11 GBytes  9.56 Gbits/sec    0    946 KBytes       
[  4]  30.00-31.00  sec  1.11 GBytes  9.56 Gbits/sec    0    952 KBytes       
[  4]  31.00-32.00  sec  1.11 GBytes  9.56 Gbits/sec    0    967 KBytes       
[  4]  32.00-33.00  sec  1.11 GBytes  9.54 Gbits/sec    0   1022 KBytes       
[  4]  33.00-34.00  sec  1.11 GBytes  9.57 Gbits/sec    0   1022 KBytes       
[  4]  34.00-35.00  sec  1.11 GBytes  9.56 Gbits/sec    0   1022 KBytes       
[  4]  35.00-36.00  sec  1.11 GBytes  9.56 Gbits/sec    0   1022 KBytes       
[  4]  36.00-37.00  sec  1.11 GBytes  9.56 Gbits/sec    0   1022 KBytes       
[  4]  37.00-38.00  sec  1.11 GBytes  9.55 Gbits/sec   34    563 KBytes       
[  4]  38.00-39.00  sec  1.11 GBytes  9.50 Gbits/sec    0    574 KBytes       
[  4]  39.00-40.00  sec  1.11 GBytes  9.56 Gbits/sec    0    580 KBytes       
[  4]  40.00-41.00  sec  1.11 GBytes  9.56 Gbits/sec    0    595 KBytes       
[  4]  41.00-42.00  sec  1.11 GBytes  9.56 Gbits/sec    0    641 KBytes       
[  4]  42.00-43.00  sec  1.11 GBytes  9.54 Gbits/sec    0    711 KBytes       
[  4]  43.00-44.00  sec  1.11 GBytes  9.56 Gbits/sec    0    748 KBytes       
[  4]  44.00-45.00  sec  1.11 GBytes  9.56 Gbits/sec    0    748 KBytes       
[  4]  45.00-46.00  sec  1.11 GBytes  9.56 Gbits/sec    0    748 KBytes       
[  4]  46.00-47.00  sec  1.11 GBytes  9.56 Gbits/sec    0    752 KBytes       
[  4]  47.00-48.00  sec  1.11 GBytes  9.56 Gbits/sec    0    752 KBytes       
[  4]  48.00-49.00  sec  1.11 GBytes  9.50 Gbits/sec    0    894 KBytes       
[  4]  49.00-50.00  sec  1.11 GBytes  9.56 Gbits/sec    0    894 KBytes       
[  4]  50.00-51.00  sec  1.11 GBytes  9.56 Gbits/sec    0    894 KBytes       
[  4]  51.00-52.00  sec  1.11 GBytes  9.56 Gbits/sec    0    894 KBytes       
[  4]  52.00-53.00  sec  1.11 GBytes  9.56 Gbits/sec    0    894 KBytes       
[  4]  53.00-54.00  sec  1.11 GBytes  9.55 Gbits/sec    0    973 KBytes       
[  4]  54.00-55.00  sec  1.11 GBytes  9.56 Gbits/sec    0    973 KBytes       
[  4]  55.00-56.00  sec  1.11 GBytes  9.56 Gbits/sec    0    973 KBytes       
[  4]  56.00-57.00  sec  1.11 GBytes  9.56 Gbits/sec    0    973 KBytes       
[  4]  57.00-58.00  sec  1.11 GBytes  9.56 Gbits/sec    0    973 KBytes       
[  4]  58.00-59.00  sec  1.11 GBytes  9.55 Gbits/sec    0   1001 KBytes       
[  4]  59.00-60.00  sec  1.11 GBytes  9.54 Gbits/sec    0   1.02 MBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-60.00  sec  65.0 GBytes  9.30 Gbits/sec  1045             sender
[  4]   0.00-60.00  sec  65.0 GBytes  9.30 Gbits/sec                  receiver

```


### End-to-End Tests

N/A yet
