### PR TITLE
feat: introduced create, delete and list proxy_port endpoints with validations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
 - Handled ``kytos/mef_eline.deployed`` event.
 - Handled ``kytos/mef_eline.(failover_link_down|failover_old_path|failover_deployed)`` events.
 - Added UI for telemetry_int.
+- Included the endpoints to create, update, delete and list proxy_port metadata, and updated OpenAPI spec. These endpoints should be used to manage the proxy_port metadata instead of directly on topology endpoints since these endpoints provide extra validations.
 
 Changed
 =======

--- a/main.py
+++ b/main.py
@@ -375,20 +375,24 @@ class Main(KytosNApp):
             for intf in switch.interfaces.copy().values():
                 if "proxy_port" in intf.metadata:
                     payload = {
-                        "interface_id": intf.id,
-                        "interface_status": intf.status.value,
-                        "interface_status_reason": sorted(intf.status_reason),
-                        "proxy_port_number": intf.metadata["proxy_port"],
-                        "proxy_port_status": "DOWN",
-                        "proxy_port_status_reason": [],
+                        "uni": {
+                            "id": intf.id,
+                            "status": intf.status.value,
+                            "status_reason": sorted(intf.status_reason)
+                        },
+                        "proxy_port": {
+                            "port_number": intf.metadata["proxy_port"],
+                            "status": "DOWN",
+                            "status_reason": []
+                        }
                     }
                     try:
                         pp = self.int_manager.get_proxy_port_or_raise(
                             intf.id, "no_evc_id"
                         )
-                        payload["proxy_port_status"] = pp.status.value
+                        payload["proxy_port"]["status"] = pp.status.value
                     except ProxyPortError as exc:
-                        payload["proxy_port_status_reason"] = [exc.message]
+                        payload["proxy_port"]["status_reason"] = [exc.message]
                     interfaces_proxy_ports.append(payload)
         return JSONResponse(interfaces_proxy_ports)
 

--- a/main.py
+++ b/main.py
@@ -32,8 +32,6 @@ from .exceptions import (
 )
 from .managers.int import INTManager
 
-# pylint: disable=fixme
-
 
 class Main(KytosNApp):
     """Main class of kytos/telemetry NApp.
@@ -304,13 +302,12 @@ class Main(KytosNApp):
         """Delete proxy port metadata."""
         intf_id = request.path_params["interface_id"]
         if (
-            (intf := self.controller.get_interface_by_id(intf_id))
-            and "proxy_port" not in intf.metadata
-        ):
+            intf := self.controller.get_interface_by_id(intf_id)
+        ) and "proxy_port" not in intf.metadata:
             return JSONResponse("Operation successful")
 
         qparams = request.query_params
-        force = True if qparams.get("force", "false").lower() == "true" else False
+        force = qparams.get("force", "false").lower() == "true"
         try:
             pp = self.int_manager.get_proxy_port_or_raise(intf_id, "no_evc_id")
             if pp.evc_ids and not force:
@@ -342,13 +339,10 @@ class Main(KytosNApp):
         qparams = request.query_params
         if not (intf := self.controller.get_interface_by_id(intf_id)):
             raise HTTPException(404, detail=f"Interface id {intf_id} not found")
-        if (
-            "proxy_port" in intf.metadata
-            and intf.metadata["proxy_port"] == port_no
-        ):
+        if "proxy_port" in intf.metadata and intf.metadata["proxy_port"] == port_no:
             return JSONResponse("Operation successful")
 
-        force = True if qparams.get("force", "false").lower() == "true" else False
+        force = qparams.get("force", "false").lower() == "true"
         try:
             pp = self.int_manager.get_proxy_port_or_raise(intf_id, "no_evc_id", port_no)
             if pp.status != EntityStatus.UP and not force:
@@ -378,13 +372,13 @@ class Main(KytosNApp):
                         "uni": {
                             "id": intf.id,
                             "status": intf.status.value,
-                            "status_reason": sorted(intf.status_reason)
+                            "status_reason": sorted(intf.status_reason),
                         },
                         "proxy_port": {
                             "port_number": intf.metadata["proxy_port"],
                             "status": "DOWN",
-                            "status_reason": []
-                        }
+                            "status_reason": [],
+                        },
                     }
                     try:
                         pp = self.int_manager.get_proxy_port_or_raise(

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from napps.kytos.telemetry_int import settings, utils
 from tenacity import RetryError
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
+from kytos.core.common import EntityStatus
 from kytos.core.helpers import alisten_to, avalidate_openapi_request, load_spec
 from kytos.core.rest_api import HTTPException, JSONResponse, Request, aget_json_or_400
 
@@ -22,6 +23,7 @@ from .exceptions import (
     EVCHasNoINT,
     EVCNotFound,
     FlowsNotFound,
+    ProxyPortError,
     ProxyPortNotFound,
     ProxyPortSameSourceIntraEVC,
     ProxyPortShared,
@@ -297,6 +299,105 @@ class Main(KytosNApp):
         ]
         return JSONResponse(response)
 
+    @rest("v1/uni/{interface_id}/proxy_port", methods=["DELETE"])
+    async def delete_proxy_port_metadata(self, request: Request) -> JSONResponse:
+        """Delete proxy port metadata."""
+        intf_id = request.path_params["interface_id"]
+        if (
+            (intf := self.controller.get_interface_by_id(intf_id))
+            and "proxy_port" not in intf.metadata
+        ):
+            return JSONResponse("Operation successful")
+
+        qparams = request.query_params
+        force = False if qparams.get("force", "false").lower() == "false" else True
+        try:
+            pp = self.int_manager.get_proxy_port_or_raise(intf_id, "no_evc_id")
+            if pp.evc_ids and not force:
+                return JSONResponse(
+                    {
+                        "status_code": 409,
+                        "code": 409,
+                        "description": f"{pp} is in use on {len(pp.evc_ids)} EVCs",
+                        "evc_ids": sorted(pp.evc_ids),
+                    },
+                    status_code=409,
+                )
+        except ProxyPortError as exc:
+            raise HTTPException(404, detail=exc.message)
+
+        try:
+            await api.delete_proxy_port_metadata(intf_id)
+            return JSONResponse("Operation successful")
+        except ValueError as exc:
+            raise HTTPException(404, detail=str(exc))
+        except UnrecoverableError as exc:
+            raise HTTPException(500, detail=str(exc))
+
+    @rest("v1/uni/{interface_id}/proxy_port/{port_number:int}", methods=["POST"])
+    async def add_proxy_port_metadata(self, request: Request) -> JSONResponse:
+        """Add proxy port metadata."""
+        intf_id = request.path_params["interface_id"]
+        port_no = request.path_params["port_number"]
+        if (
+            (intf := self.controller.get_interface_by_id(intf_id))
+            and "proxy_port" in intf.metadata
+            and intf.metadata["proxy_port"] == port_no
+        ):
+            return JSONResponse("Operation successful")
+
+        qparams = request.query_params
+        force = False if qparams.get("force", "false").lower() == "false" else True
+        try:
+            pp = self.int_manager.get_proxy_port_or_raise(intf_id, "no_evc_id", port_no)
+            if pp.status != EntityStatus.UP and not force:
+                raise HTTPException(409, detail=f"{pp} status isn't UP")
+            self.int_manager._validate_dedicated_proxy_port_evcs(
+                {
+                    "no_evc_id": {
+                        "uni_a": {"interface_id": intf_id, "proxy_port": pp},
+                        "uni_z": {"interface_id": intf_id, "proxy_port": pp},
+                    }
+                }
+            )
+        except ProxyPortShared as exc:
+            raise HTTPException(409, detail=exc.message)
+        except ProxyPortError as exc:
+            raise HTTPException(404, detail=exc.message)
+
+        try:
+            await api.add_proxy_port_metadata(intf_id, port_no)
+            return JSONResponse("Operation successful")
+        except ValueError as exc:
+            raise HTTPException(404, detail=str(exc))
+        except UnrecoverableError as exc:
+            raise HTTPException(500, detail=str(exc))
+
+    @rest("v1/uni/proxy_port")
+    async def list_uni_proxy_ports(self, _request: Request) -> JSONResponse:
+        """List configured UNI proxy ports."""
+        interfaces_proxy_ports = []
+        for switch in self.controller.switches.copy().values():
+            for intf in switch.interfaces.copy().values():
+                if "proxy_port" in intf.metadata:
+                    payload = {
+                        "interface_id": intf.id,
+                        "interface_status": intf.status.value,
+                        "interface_status_reason": sorted(intf.status_reason),
+                        "proxy_port_number": intf.metadata["proxy_port"],
+                        "proxy_port_status": "DOWN",
+                        "proxy_port_status_reason": [],
+                    }
+                    try:
+                        pp = self.int_manager.get_proxy_port_or_raise(
+                            intf.id, "no_evc_id"
+                        )
+                        payload["proxy_port_status"] = pp.status.value
+                    except ProxyPortError as exc:
+                        payload["proxy_port_status_reason"] = [exc.message]
+                    interfaces_proxy_ports.append(payload)
+        return JSONResponse(interfaces_proxy_ports)
+
     @alisten_to("kytos/mef_eline.evcs_loaded")
     async def on_mef_eline_evcs_loaded(self, event: KytosEvent) -> None:
         """Handle kytos/mef_eline.evcs_loaded."""
@@ -549,24 +650,3 @@ class Main(KytosNApp):
     async def on_intf_metadata_added(self, event: KytosEvent) -> None:
         """On interface metadata added."""
         await self.int_manager.handle_pp_metadata_added(event.content["interface"])
-
-    # Event-driven methods: future
-    def listen_for_new_evcs(self):
-        """Change newly created EVC to INT-enabled EVC based on the metadata field
-        (future)"""
-        pass
-
-    def listen_for_evc_change(self):
-        """Change newly created EVC to INT-enabled EVC based on the
-        metadata field (future)"""
-        pass
-
-    def listen_for_path_changes(self):
-        """Change EVC's new path to INT-enabled EVC based on the metadata field
-        when there is a path change. (future)"""
-        pass
-
-    def listen_for_topology_changes(self):
-        """If the topology changes, make sure it is not the loop ports.
-        If so, update proxy ports"""
-        pass

--- a/openapi.yml
+++ b/openapi.yml
@@ -226,6 +226,7 @@ paths:
           description: Internal Server Error
         '503':
           description: Service unavailable
+  /v1/uni/{interface_id}/proxy_port:
     delete:
       summary: Delete proxy port metadata on a UNI
       description: Delete proxy port metadata on a UNI. It will only delete the metadata if no INT EVCs are using this port, unless you use the force option. When metadata is removed, INT will be disabled.
@@ -237,16 +238,11 @@ paths:
           required: true
           description: The interface ID
           in: path
-        - name: port_number
-          schema:
-            type: integer
-          required: true
-          description: The proxy port number
-          in: path
         - name: force
           schema:
             type: boolean
           in: query
+          required: false
           description: Force metadata deletion even if there are INT EVCs using the proxy port
       responses:
         '200':
@@ -301,7 +297,26 @@ components:
     ProxyPortListResp: # Can be referenced via '#/components/schemas/ProxyPortListResp'
       type: object
       properties:
-        interface_id:
-          type: string
+        uni:
+          type: object
+          properties:
+            id:
+              type: string
+            status:
+              type: string
+            status_reason:
+              type: array
+              items:
+                type: string
         proxy_port:
-          type: integer
+          type: object
+          properties:
+            port_number:
+              type: integer
+            status:
+              type: string
+            status_reason:
+              type: array
+              items:
+                type: string
+

--- a/openapi.yml
+++ b/openapi.yml
@@ -170,6 +170,112 @@ paths:
           description: Internal Server Error
         '503':
           description: Service unavailable
+  /v1/uni/proxy_port:
+    get:
+      summary: List the existing UNIs and the configured proxy ports
+      operationId: list_proxy_ports
+      responses:
+        '200':
+          description: List the existing configured proxy ports
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ProxyPortListResp'
+        '500':
+          description: Internal Server Error
+        '503':
+          description: Service unavailable
+  /v1/uni/{interface_id}/proxy_port/{port_number}:
+    post:
+      summary: Set proxy port metadata on a UNI
+      description: Set proxy port metadata on a UNI. Each UNI should use a different proxy port. If the proxy port is being updated, INT will be redeployed. If the proxy port is being set for the first time, you will need to enable INT on EVC afterwards.
+      operationId: set_proxy_port
+      parameters:
+        - name: interface_id
+          schema:
+            type: string
+          required: true
+          description: The interface ID
+          in: path
+        - name: port_number
+          schema:
+            type: integer
+          required: true
+          description: The proxy port number
+          in: path
+        - name: force
+          schema:
+            type: boolean
+          required: false
+          description: If force is set, it will also accept a proxy_port that isn't UP
+          in: query
+      responses:
+        '200':
+          description: Operation sucessful
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Operation sucessful
+        '404':
+          description: Interface id or proxy port not found
+        '409':
+          description: Proxy port conflict
+        '500':
+          description: Internal Server Error
+        '503':
+          description: Service unavailable
+    delete:
+      summary: Delete proxy port metadata on a UNI
+      description: Delete proxy port metadata on a UNI. It will only delete the metadata if no INT EVCs are using this port, unless you use the force option. When metadata is removed, INT will be disabled.
+      operationId: del_proxy_port
+      parameters:
+        - name: interface_id
+          schema:
+            type: string
+          required: true
+          description: The interface ID
+          in: path
+        - name: port_number
+          schema:
+            type: integer
+          required: true
+          description: The proxy port number
+          in: path
+        - name: force
+          schema:
+            type: boolean
+          in: query
+          description: Force metadata deletion even if there are INT EVCs using the proxy port
+      responses:
+        '200':
+          description: Operation sucessful.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: Operation sucessful
+        '404':
+          description: Interface id or proxy port not found
+        '409':
+          description: Proxy port deletion conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  description:
+                    type: string
+                  evc_ids:
+                    type: array
+                    items:
+                      type: string
+        '500':
+          description: Internal Server Error
+        '503':
+          description: Service unavailable
+
 
 
 components:
@@ -192,3 +298,10 @@ components:
           type: array
           items:
             type: string
+    ProxyPortListResp: # Can be referenced via '#/components/schemas/ProxyPortListResp'
+      type: object
+      properties:
+        interface_id:
+          type: string
+        proxy_port:
+          type: integer

--- a/settings.py
+++ b/settings.py
@@ -3,6 +3,7 @@
 KYTOS_API = "http://0.0.0.0:8181/api"
 mef_eline_api = f"{KYTOS_API}/kytos/mef_eline/v2"
 flow_manager_api = f"{KYTOS_API}/kytos/flow_manager/v2"
+topology_url = f"{KYTOS_API}/kytos/topology/v3"
 INT_COOKIE_PREFIX = 0xA8
 MEF_COOKIE_PREFIX = 0xAA
 IPv4 = 2048

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,10 @@ class TestCoverage(Test):
 
     def run(self):
         """Run tests quietly and display coverage report."""
-        cmd = "python3 -m pytest --cov=. tests/ %s" % self.get_args()
+        cmd = (
+            "python3 -m pytest --cov=. --cov-report term-missing tests/ %s"
+            % self.get_args()
+        )
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -223,7 +223,7 @@ class TestINTManager:
         assert "proxy_port" not in intf_mock.metadata
         monkeypatch.setattr("napps.kytos.telemetry_int.managers.int.api", api_mock)
         api_mock.get_evcs.return_value = {evc_id: {}}
-        int_manager.remove_int_flows = AsyncMock()
+        int_manager.disable_int = AsyncMock()
 
         await int_manager.handle_pp_metadata_removed(intf_mock)
         assert api_mock.get_evcs.call_count == 1
@@ -232,15 +232,9 @@ class TestINTManager:
             "metadata.telemetry.enabled": "true",
             "metadata.telemetry.status": "UP",
         }
-        assert int_manager.remove_int_flows.call_count == 1
-        args = int_manager.remove_int_flows.call_args[0]
+        assert int_manager.disable_int.call_count == 1
+        args = int_manager.disable_int.call_args[0]
         assert evc_id in args[0]
-        assert "telemetry" in args[1]
-        telemetry = args[1]["telemetry"]
-        assert telemetry["enabled"]
-        assert telemetry["status"] == "DOWN"
-        assert telemetry["status_reason"] == ["proxy_port_metadata_removed"]
-        assert "status_updated_at" in telemetry
 
     async def test_handle_pp_metadata_added(self, monkeypatch):
         """Test handle_pp_metadata_added."""

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -577,11 +577,11 @@ class TestINTManager:
         controller = get_controller_mock()
         int_manager = INTManager(controller)
         pp = MagicMock()
-        mock = MagicMock()
-        int_manager.get_proxy_port_or_raise = mock
-        mock.return_value = pp
+        int_manager.unis_src[intf_id_a] = "a"
+        int_manager.unis_src[intf_id_z] = "z"
+        int_manager.srcs_pp[int_manager.unis_src[intf_id_a]] = pp
+        int_manager.srcs_pp[int_manager.unis_src[intf_id_z]] = pp
         int_manager._discard_pps_evc_ids(evcs)
-        assert int_manager.get_proxy_port_or_raise.call_count == 2
         assert pp.evc_ids.discard.call_count == 2
         pp.evc_ids.discard.assert_called_with(evc_id)
 

--- a/tests/unit/test_kytos_api_helper.py
+++ b/tests/unit/test_kytos_api_helper.py
@@ -4,6 +4,8 @@ from httpx import Response
 from unittest.mock import AsyncMock, MagicMock
 from napps.kytos.telemetry_int.kytos_api_helper import (
     add_evcs_metadata,
+    add_proxy_port_metadata,
+    delete_proxy_port_metadata,
     get_evc,
     get_stored_flows,
     get_evcs,
@@ -105,3 +107,27 @@ async def test_add_evcs_metadata(monkeypatch):
         {"some_id": {"id": "some_id"}}, {"some_key": "some_val"}
     )
     assert data == resp
+
+
+async def test_add_proxy_port_metadata(monkeypatch):
+    """test add_proxy_port_metadata."""
+    aclient_mock, awith_mock = AsyncMock(), MagicMock()
+    resp = "Operation successful"
+    aclient_mock.post.return_value = Response(201, json=resp, request=MagicMock())
+    awith_mock.return_value.__aenter__.return_value = aclient_mock
+    monkeypatch.setattr("httpx.AsyncClient", awith_mock)
+    intf_id, port_no = "00:00:00:00:00:00:00:01:1", 7
+    data = await add_proxy_port_metadata(intf_id, port_no)
+    assert data
+
+
+async def test_delete_proxy_port_metadata(monkeypatch):
+    """test delete_proxy_port_metadata."""
+    aclient_mock, awith_mock = AsyncMock(), MagicMock()
+    resp = "Operation successful"
+    aclient_mock.post.return_value = Response(201, json=resp, request=MagicMock())
+    awith_mock.return_value.__aenter__.return_value = aclient_mock
+    monkeypatch.setattr("httpx.AsyncClient", awith_mock)
+    intf_id = "00:00:00:00:00:00:00:01:1"
+    data = await delete_proxy_port_metadata(intf_id)
+    assert data


### PR DESCRIPTION
Closes #112 

### Summary

See updated changelog file 

### Local Tests

- Exercises many cases, including updating a proxy port and UNI values and all the crud operations on the new endpoints, they all behaved as expected:


```
❯ http http://localhost:8181/api/kytos/telemetry_int/v1/uni/proxy_port
HTTP/1.1 200 OK
content-length: 421
content-type: application/json
date: Thu, 08 Aug 2024 14:59:25 GMT
server: uvicorn

[
    {
        "proxy_port": {
            "port_number": 5,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:01:1",
            "status": "UP",
            "status_reason": []
        }
    },
    {
        "proxy_port": {
            "port_number": 7,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:01:2",
            "status": "UP",
            "status_reason": []
        }
    },
    {
        "proxy_port": {
            "port_number": 5,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:03:1",
            "status": "UP",
            "status_reason": []
        }
    }
]



❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:1/proxy_port/5
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Thu, 08 Aug 2024 14:59:59 GMT
server: uvicorn

"Operation successful"



❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:1/proxy_port/8
HTTP/1.1 404 Not Found
content-length: 118
content-type: application/json
date: Thu, 08 Aug 2024 15:00:18 GMT
server: uvicorn

{
    "code": 404,
    "description": "proxy_port 8 of 00:00:00:00:00:00:00:01:1 isn't looped or destination interface not found"
}



❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:9/proxy_port/8
HTTP/1.1 404 Not Found
content-length: 77
content-type: application/json
date: Thu, 08 Aug 2024 15:00:36 GMT
server: uvicorn

{
    "code": 404,
    "description": "Interface id 00:00:00:00:00:00:00:01:9 not found"
}



❯ 

❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:1/proxy_port/7
HTTP/1.1 409 Conflict
content-length: 164
content-type: application/json
date: Thu, 08 Aug 2024 15:00:53 GMT
server: uvicorn

{
    "code": 409,
    "description": "UNI 00:00:00:00:00:00:00:01:1 must use another dedicated proxy port. UNI 00:00:00:00:00:00:00:01:2 is already using proxy_port number 7"
}



❯ http DELETE  http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:2/proxy_port/ 
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Thu, 08 Aug 2024 15:02:02 GMT
server: uvicorn

"Operation successful"



❯ http http://localhost:8181/api/kytos/telemetry_int/v1/uni/proxy_port                              
HTTP/1.1 200 OK
content-length: 281
content-type: application/json
date: Thu, 08 Aug 2024 15:02:07 GMT
server: uvicorn

[
    {
        "proxy_port": {
            "port_number": 5,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:01:1",
            "status": "UP",
            "status_reason": []
        }
    },
    {
        "proxy_port": {
            "port_number": 5,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:03:1",
            "status": "UP",
            "status_reason": []
        }
    }
]



❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:1/proxy_port/7  
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Thu, 08 Aug 2024 15:02:10 GMT
server: uvicorn

"Operation successful"



❯ http http://localhost:8181/api/kytos/telemetry_int/v1/uni/proxy_port                                 
HTTP/1.1 200 OK
content-length: 281
content-type: application/json
date: Thu, 08 Aug 2024 15:02:13 GMT
server: uvicorn

[
    {
        "proxy_port": {
            "port_number": 7,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:01:1",
            "status": "UP",
            "status_reason": []
        }
    },
    {
        "proxy_port": {
            "port_number": 5,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:03:1",
            "status": "UP",
            "status_reason": []
        }
    }
]



❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:1/proxy_port/5
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Thu, 08 Aug 2024 15:02:19 GMT
server: uvicorn

"Operation successful"



❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:2/proxy_port/5
HTTP/1.1 409 Conflict
content-length: 164
content-type: application/json
date: Thu, 08 Aug 2024 15:02:26 GMT
server: uvicorn

{
    "code": 409,
    "description": "UNI 00:00:00:00:00:00:00:01:2 must use another dedicated proxy port. UNI 00:00:00:00:00:00:00:01:1 is already using proxy_port number 5"
}



❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:2/proxy_port/7
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Thu, 08 Aug 2024 15:02:29 GMT
server: uvicorn

"Operation successful"



❯ http http://localhost:8181/api/kytos/telemetry_int/v1/uni/proxy_port                                 
HTTP/1.1 200 OK
content-length: 421
content-type: application/json
date: Thu, 08 Aug 2024 15:02:32 GMT
server: uvicorn

[
    {
        "proxy_port": {
            "port_number": 5,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:01:1",
            "status": "UP",
            "status_reason": []
        }
    },
    {
        "proxy_port": {
            "port_number": 7,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:01:2",
            "status": "UP",
            "status_reason": []
        }
    },
    {
        "proxy_port": {
            "port_number": 5,
            "status": "UP",
            "status_reason": []
        },
        "uni": {
            "id": "00:00:00:00:00:00:00:03:1",
            "status": "UP",
            "status_reason": []
        }
    }
]





❯ http DELETE  http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:1/proxy_port/
HTTP/1.1 409 Conflict
content-length: 242
content-type: application/json
date: Thu, 08 Aug 2024 15:16:25 GMT
server: uvicorn

{
    "code": 409,
    "description": "ProxyPort(Interface('s1-eth5', 5, Switch('00:00:00:00:00:00:00:01')), Interface('s1-eth6', 6, Switch('00:00:00:00:00:00:00:01')), EntityStatus.UP) is in use on 1 EVCs
",
    "evc_ids": [
        "5be4384312bc4b"
    ],
    "status_code": 409
}



❯ http DELETE  http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:1/proxy_port/\?force\=true
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Thu, 08 Aug 2024 15:17:28 GMT
server: uvicorn

"Operation successful"




kytos $> 2024-08-08 12:17:28,310 - INFO [uvicorn.access] (MainThread) 127.0.0.1:38034 - "DELETE /api/kytos/topology/v3/interfaces/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01%3A1/metadata/proxy
_port HTTP/1.1" 200
2024-08-08 12:17:28,315 - INFO [uvicorn.access] (MainThread) 127.0.0.1:38028 - "DELETE /api/kytos/telemetry_int/v1/uni/00%3A00%3A00%3A00%3A00%3A00%3A00%3A01%3A1/proxy_port/?force=true HT
TP/1.1" 200
2024-08-08 12:17:28,318 - INFO [uvicorn.access] (MainThread) 127.0.0.1:38038 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=true&metadata.telemetry.status=
UP HTTP/1.1" 200
2024-08-08 12:17:28,318 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling interface metadata removed on Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01')), it'll dis
able INT falling back to mef_eline, EVC ids: ['5be4384312bc4b']
2024-08-08 12:17:28,319 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Disabling INT on EVC ids: ['5be4384312bc4b'], force: True
2024-08-08 12:17:28,326 - INFO [uvicorn.access] (MainThread) 127.0.0.1:38054 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200



2024-08-08 12:42:55,923 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60804 - "GET /api/kytos/mef_eline/v2/evc/?archived=false&metadata.telemetry.enabled=true HTTP/1.1" 200
2024-08-08 12:42:55,924 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling interface metadata updated on Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01')). It'll di
sable the EVCs to be safe, and then try to enable again with the updated  proxy port ProxyPort(Interface('s1-eth5', 5, Switch('00:00:00:00:00:00:00:01')), Interface('s1-eth6', 6, Switch
('00:00:00:00:00:00:00:01')), EntityStatus.UP), EVC ids: ['5be4384312bc4b']
2024-08-08 12:42:55,924 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Disabling INT on EVC ids: ['5be4384312bc4b'], force: True
2024-08-08 12:42:55,931 - INFO [uvicorn.access] (MainThread) 127.0.0.1:60816 - "GET /api/kytos/flow_manager/v2/stored_flows?state=installed&state=pending HTTP/1.1" 200




❯ ./trace_evpl_2222_6_rev.sh
HTTP/1.1 200 OK
content-length: 369
content-type: application/json
date: Thu, 08 Aug 2024 16:27:19 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 22,
            "time": "2024-08-08 13:27:20.342379",
            "type": "starting",
            "vlan": 2222
        },
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 11,
            "time": "2024-08-08 13:27:20.342431",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "out": {
                "port": 15,
                "vlan": 2222
            },
            "port": 20,
            "time": "2024-08-08 13:27:20.342472",
            "type": "last",
            "vlan": 1
        }
    ]
}



~/repos/amnoviflow master* 
❯ http POST http://localhost:8181/api/kytos/telemetry_int/v1/uni/00:00:00:00:00:00:00:01:15/proxy_port/17
HTTP/1.1 200 OK
content-length: 22
content-type: application/json
date: Thu, 08 Aug 2024 16:27:52 GMT
server: uvicorn

"Operation successful"



~/repos/amnoviflow master* 
❯ ./trace_evpl_2222_6_rev.sh                                                                             
HTTP/1.1 200 OK
content-length: 369
content-type: application/json
date: Thu, 08 Aug 2024 16:27:56 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 22,
            "time": "2024-08-08 13:27:57.446842",
            "type": "starting",
            "vlan": 2222
        },
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 11,
            "time": "2024-08-08 13:27:57.446874",
            "type": "intermediary",
            "vlan": 1
        },
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "out": {
                "port": 15,
                "vlan": 2222
            },
            "port": 18,
            "time": "2024-08-08 13:27:57.446884",
            "type": "last",
            "vlan": 1
        }
    ]
}





```

### End-to-End Tests

N/A yet
