### PR TITLE
hotfix 2024.1.2: Prevented shared flow accidental mutability when handling failover flows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.2] - 2024-08-30
+***********************
+
+Fixed
+=====
+- Prevented shared flow accidental mutability when handling failover flows events
+
+
 [2024.1.1] - 2024-08-21
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "telemetry_int",
   "description": "Napp to deploy In-band Network Telemetry for EVCs",
-  "version": "2024.1.1",
+  "version": "2024.1.2",
   "napp_dependencies": ["amlight/noviflow", "kytos/mef_eline"],
   "license": "MIT",
   "tags": ["INT"],

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ Napp to deploy In-band Network Telemetry over Ethernet Virtual Circuits
 """
 
 import asyncio
+import copy
 import pathlib
 from datetime import datetime
 
@@ -534,21 +535,21 @@ class Main(KytosNApp):
     async def on_failover_link_down(self, event: KytosEvent):
         """Handle kytos/mef_eline.failover_link_down."""
         await self.int_manager.handle_failover_flows(
-            event.content, event_name="failover_link_down"
+            copy.deepcopy(event.content), event_name="failover_link_down"
         )
 
     @alisten_to("kytos/mef_eline.failover_old_path")
     async def on_failover_old_path(self, event: KytosEvent):
         """Handle kytos/mef_eline.failover_old_path."""
         await self.int_manager.handle_failover_flows(
-            event.content, event_name="failover_old_path"
+            copy.deepcopy(event.content), event_name="failover_old_path"
         )
 
     @alisten_to("kytos/mef_eline.failover_deployed")
     async def on_failover_deployed(self, event: KytosEvent):
         """Handle kytos/mef_eline.failover_deployed."""
         await self.int_manager.handle_failover_flows(
-            event.content, event_name="failover_deployed"
+            copy.deepcopy(event.content), event_name="failover_deployed"
         )
 
     @alisten_to("kytos/topology.link_down")


### PR DESCRIPTION


Closes #129 

### Summary

- See updated changelog file 
- As mentioned on issue 129, this wasn't absolutely necessary here yet, since mef_eline is already copying, but to avoid future accidental and making the intention clear, it's appropriate to already ship this, and it's expected that the number of flows here wouldn't bee to high (hundreds of thousands) in these events, so the deepcopy at the moment, isn't expected to be too expensive to compute

### Local Tests

- Created an INT evpl, simulated failover events, and traced:

```
kytos $> 2024-08-30 10:27:30,881 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:01:11 state OFPPS_LINK_DOWN
2024-08-30 10:27:30,885 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) Event handle_link_down Link(Interface('novi_port_11', 11, Switch('00:00:00:00:00:00:00:01')), Interface(
'novi_port_11', 11, Switch('00:00:00:00:00:00:00:06')), d7e3aade462df35a656320b717e8603a7fd624c4cfb7dcb72feafe95c6be1c96)
2024-08-30 10:27:30,893 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) EVC(011c1b95758149, inter_evpl_2222) redeployed with failover due to link down d7e3aade462df35a656320b71
7e8603a7fd624c4cfb7dcb72feafe95c6be1c96
2024-08-30 10:27:30,896 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_18) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: True, total_length
: 1,  flows[0, 1]: [{'match': {'in_port': 15, 'dl_vlan': 2222}, 'cookie': 12250103366221660489, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', '
vlan_id': 1}, {'action_type': 'output', 'port': 2}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-08-30 10:27:30,905 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_3) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: True, total_length:
 1,  flows[0, 1]: [{'match': {'in_port': 22, 'dl_vlan': 2222}, 'cookie': 12250103366221660489, 'actions': [{'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'v
lan_id': 1}, {'action_type': 'output', 'port': 5}], 'owner': 'mef_eline', 'table_group': 'evpl', 'table_id': 0, 'priority': 20000}]
2024-08-30 10:27:30,912 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling failover_link_down flows install on EVC ids: dict_keys(['011c1b95758149'])
2024-08-30 10:27:30,916 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: add, force: True, total_length: 
1,  flows[0, 1]: [{'match': {'in_port': 15, 'dl_vlan': 2222}, 'cookie': 12105988178145804617, 'owner': 'telemetry_int', 'table_group': 'evpl', 'table_id': 2, 'priority': 20000, 'instru
ctions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1
}, {'action_type': 'output', 'port': 2}]}]}]
2024-08-30 10:27:30,925 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: add, force: True, total_length: 
1,  flows[0, 1]: [{'match': {'in_port': 22, 'dl_vlan': 2222}, 'cookie': 12105988178145804617, 'owner': 'telemetry_int', 'table_group': 'evpl', 'table_id': 2, 'priority': 20000, 'instru
ctions': [{'instruction_type': 'apply_actions', 'actions': [{'action_type': 'add_int_metadata'}, {'action_type': 'push_vlan', 'tag_type': 's'}, {'action_type': 'set_vlan', 'vlan_id': 1
}, {'action_type': 'output', 'port': 5}]}]}]
2024-08-30 10:27:30,930 - INFO [kytos.napps.kytos/of_core] (MainThread) PortStatus modified interface 00:00:00:00:00:00:00:06:11 state OFPPS_LINK_DOWN
2024-08-30 10:27:30,931 - INFO [kytos.napps.kytos/telemetry_int] (MainThread) Handling failover_old_path flows remove on EVC ids: dict_keys(['011c1b95758149'])
2024-08-30 10:27:30,932 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_14) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True, total_len
gth: 1,  flows[0, 1]: [{'cookie': 12250103366221660489, 'match': {'in_port': 11, 'dl_vlan': 1}, 'owner': 'mef_eline', 'cookie_mask': 18446744073709551615}]
2024-08-30 10:27:30,934 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:01, command: delete, force: True, total_lengt
h: 1,  flows[0, 1]: [{'cookie': 12105988178145804617, 'match': {'in_port': 11, 'dl_vlan': 1}, 'owner': 'telemetry_int', 'cookie_mask': 18446744073709551615, 'priority': 21000, 'table_g
roup': 'evpl'}]
2024-08-30 10:27:30,935 - INFO [kytos.napps.kytos/flow_manager] (thread_pool_app_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: delete, force: True, total_leng
th: 1,  flows[0, 1]: [{'cookie': 12250103366221660489, 'match': {'in_port': 11, 'dl_vlan': 1}, 'owner': 'mef_eline', 'cookie_mask': 18446744073709551615}]
2024-08-30 10:27:30,946 - INFO [kytos.napps.kytos/flow_manager] (dynamic_single_0) Send FlowMod from KytosEvent dpid: 00:00:00:00:00:00:00:06, command: delete, force: True, total_lengt
h: 1,  flows[0, 1]: [{'cookie': 12105988178145804617, 'match': {'in_port': 11, 'dl_vlan': 1}, 'owner': 'telemetry_int', 'cookie_mask': 18446744073709551615, 'priority': 21000, 'table_g
roup': 'evpl'}]
2024-08-30 10:27:30,985 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_30) Event handle_interface_link_down Interface('novi_port_11', 11, Switch('00:00:00:00:00:00:00:01'))
2024-08-30 10:27:31,032 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_sb_23) Event handle_interface_link_down Interface('novi_port_11', 11, Switch('00:00:00:00:00:00:00:06'))
kytos $> 
```

### End-to-End Tests

N/A, this NApp doesn't have e2e tests yet
