### PR TITLE
Added missing tag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Changed
 =======
 - The telemetry_int modal now uses the modal component
 
+Fixed
+=====
+- Added missing ``k-button-group`` end tag within ``show_telemetry_int_data`` k-info-panel
+
 [2024.1.2] - 2024-08-30
 ***********************
 

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -8,7 +8,7 @@
                         <k-button icon="comment" title="Enable Selected" tooltip="Enable INT on selected EVCs" @click="enableSelectedEVCs()"></k-button>
                         <k-button icon="comment-slash" title="Disable Selected" tooltip="Disable INT on selected EVCs" @click="displayModal()"></k-button>
                         <k-button icon="truck-moving" title="Redeploy Selected" tooltip="Redeploy INT on selected EVCs" @click="redeploySelectedEVCs()"></k-button>
-                    <k-button-group>
+                    </k-button-group>
                     <k-checkbox title="Force" v-model:model="forceOption" :value="true"></k-checkbox>
                 </k-accordion-item>
                 <!--


### PR DESCRIPTION
Closes #139 

### Summary

There was a missing closing tag within the `show_telemetry_int_data` info panel.

### Local Tests

### End-to-End Tests
