### PR TITLE
fixed `get_id_from_cookie(cookie)` evc_id conversion leading zeros issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+Fixed
+=====
+- Fixed ``get_id_from_cookie(cookie)`` utility function, now it handles EVC id with leading zeros correctly. This function is used in flow mod error handling and also in the ``GET v1/evc/compare`` endpoint
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -81,8 +81,8 @@ def test_get_new_cookie(cookie, expected) -> None:
     [
         (0xAA3766C105686749, "3766c105686749"),
         (0xAACBEE9338673946, "cbee9338673946"),
-        (0xAA0F756E60d34E4B, "0f756e60d34e4b"),
-        (0xAA00756E60d34E4B, "00756e60d34e4b")
+        (0xAA0F756E60D34E4B, "0f756e60d34e4b"),
+        (0xAA00756E60D34E4B, "00756e60d34e4b"),
     ],
 )
 def test_get_id_from_cookie(cookie, expected_evc_id) -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -81,6 +81,8 @@ def test_get_new_cookie(cookie, expected) -> None:
     [
         (0xAA3766C105686749, "3766c105686749"),
         (0xAACBEE9338673946, "cbee9338673946"),
+        (0xAA0F756E60d34E4B, "0f756e60d34e4b"),
+        (0xAA00756E60d34E4B, "00756e60d34e4b")
     ],
 )
 def test_get_id_from_cookie(cookie, expected_evc_id) -> None:

--- a/utils.py
+++ b/utils.py
@@ -87,7 +87,7 @@ def get_cookie(evc_id: str, cookie_prefix: int) -> int:
 def get_id_from_cookie(cookie: int) -> str:
     """Return the evc id given a cookie value."""
     evc_id = cookie & 0xFFFFFFFFFFFFFF
-    return f"{evc_id:x}"
+    return f"{evc_id:x}".zfill(14)
 
 
 def is_intra_switch_evc(evc):


### PR DESCRIPTION
Closes #154 

### Summary

- Same as https://github.com/kytos-ng/telemetry_int/pull/156 
- See updated changelog file 

### Local Tests

- Same as the linked backport PR

### End-to-End Tests

- N/A yet
