### PR TITLE
feat:  `proxy_port_enabled` metadata config at the EVC level

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Changed
 - ``proxy_port`` is now optional by default for inter EVCs
 - Internal refactoring updating UI components to use ``pinia``
 
+Added
+=====
+- EVC metadata ``proxy_port_enabled`` can overwrite whether or not a ``proxy_port`` should be used by an inter EVC. This unlocks EVPLs that shouldn't be using proxy port over UNIs that have proxy ports configured
+- Added UI for selecting ``proxy_port_enabled`` option and displaying it
+
 [2025.1.0] - 2025-04-14
 ***********************
 

--- a/managers/flow_builder.py
+++ b/managers/flow_builder.py
@@ -275,9 +275,23 @@ class FlowBuilder:
         stored_flows: dict[int, list[dict]],
     ) -> list[dict]:
         """Build INT sink flows."""
-        if "proxy_port" in evc[uni_dst_key]:
-            return self._build_int_sink_flows_proxy_port(uni_dst_key, evc, stored_flows)
-        return self._build_int_sink_flows_no_proxy_port(uni_dst_key, evc, stored_flows)
+        match utils.get_evc_proxy_port_value(evc):
+            case True:
+                return self._build_int_sink_flows_proxy_port(
+                    uni_dst_key, evc, stored_flows
+                )
+            case False:
+                return self._build_int_sink_flows_no_proxy_port(
+                    uni_dst_key, evc, stored_flows
+                )
+            case _:
+                if "proxy_port" in evc[uni_dst_key]:
+                    return self._build_int_sink_flows_proxy_port(
+                        uni_dst_key, evc, stored_flows
+                    )
+                return self._build_int_sink_flows_no_proxy_port(
+                    uni_dst_key, evc, stored_flows
+                )
 
     def _build_int_sink_flows_proxy_port(
         self,

--- a/managers/int.py
+++ b/managers/int.py
@@ -20,6 +20,8 @@ from napps.kytos.telemetry_int.managers.flow_builder import FlowBuilder
 from kytos.core.common import EntityStatus
 from napps.kytos.telemetry_int.proxy_port import ProxyPort
 
+from tenacity import RetryError
+
 from napps.kytos.telemetry_int.exceptions import (
     EVCError,
     EVCNotFound,
@@ -36,6 +38,7 @@ from napps.kytos.telemetry_int.exceptions import (
     ProxyPortRequired,
     ProxyPortSameSourceIntraEVC,
     ProxyPortShared,
+    UnrecoverableError,
 )
 
 
@@ -231,13 +234,25 @@ class INTManager:
             if not affected_evcs:
                 return
 
+            affected_evcs_list = list(affected_evcs)
             log.info(
                 f"Handling interface metadata removed on {intf}, it'll disable INT "
-                f"falling back to mef_eline, EVC ids: {list(affected_evcs)}"
+                f"falling back to mef_eline, EVC ids: {affected_evcs_list}"
             )
-            await self.disable_int(
-                affected_evcs, force=True, reason="proxy_port_metadata_removed"
-            )
+            try:
+                await self.disable_int(
+                    affected_evcs, force=True, reason="proxy_port_metadata_removed"
+                )
+            except (EVCError, RetryError) as exc:
+                exc_error = str(exc)
+                if isinstance(exc, RetryError):
+                    exc_error = str(exc.last_attempt.exception())
+                log.error(
+                    f"Failed to disable INT, Exception: {exc_error}, "
+                    f"when handling intf metadata removed on {intf}, {pp}"
+                    "You need to force disable INT on these EVC ids: "
+                    f"{affected_evcs_list}"
+                )
 
     async def handle_pp_metadata_added(self, intf: Interface) -> None:
         """Handle proxy port metadata added.
@@ -272,20 +287,36 @@ class INTManager:
             if not affected_evcs:
                 return
 
+            affected_evcs_list = list(affected_evcs)
             log.info(
                 f"Handling interface metadata updated on {intf}. It'll disable the "
                 "EVCs to be safe, and then try to enable again with the updated "
-                f" proxy port {pp}, EVC ids: {list(affected_evcs)}"
+                f" proxy port {pp}, EVC ids: {affected_evcs_list}"
             )
-            await self.disable_int(
-                affected_evcs, force=True, reason="proxy_port_metadata_added"
-            )
+            try:
+                await self.disable_int(
+                    affected_evcs, force=True, reason="proxy_port_metadata_added"
+                )
+            except (EVCError, RetryError) as exc:
+                exc_error = str(exc)
+                if isinstance(exc, RetryError):
+                    exc_error = str(exc.last_attempt.exception())
+                log.error(
+                    f"Failed to disable INT, Exception: {exc_error}, "
+                    f"when handling intf metadata updated on {intf}, {pp}"
+                    "You need to force disable and then enable INT on these EVC ids: "
+                    f"{affected_evcs_list}"
+                )
+                return
+
             try:
                 await self.enable_int(affected_evcs, force=True)
             except ProxyPortConflict as exc:
                 msg = (
                     f"Validation error when updating interface {intf}"
-                    f" EVC ids: {list(affected_evcs)}, exception {str(exc)}"
+                    f" EVC ids: {affected_evcs_list}, exception {str(exc)}. "
+                    " You need to solve the proxy port conflict config and then "
+                    " enable INT again"
                 )
                 log.error(msg)
                 metadata = {
@@ -298,7 +329,29 @@ class INTManager:
                         ),
                     }
                 }
-                await api.add_evcs_metadata(affected_evcs, metadata)
+
+                try:
+                    await api.add_evcs_metadata(affected_evcs, metadata)
+                except (RetryError, UnrecoverableError) as exc:
+                    exc_error = str(exc)
+                    if isinstance(exc, RetryError):
+                        exc_error = str(exc.last_attempt.exception())
+                    log.error(
+                        f"Failed to set INT metadata, Exception: {exc_error}, "
+                        f"when handling intf metadata updated on {intf}, {pp}"
+                        "You need to solve the proxy port conflict and then "
+                        " force enable INT on these EVC ids: "
+                        f"{affected_evcs_list}"
+                    )
+            except (EVCError, RetryError) as exc:
+                exc_error = str(exc)
+                if isinstance(exc, RetryError):
+                    exc_error = str(exc.last_attempt.exception())
+                log.error(
+                    f"Failed to re-enable INT, Exception: {exc_error}, "
+                    f"when handling intf metadata updated on {intf}, {pp}"
+                    f"You need to enable INT on these EVC ids: {affected_evcs_list}"
+                )
 
     async def disable_int(
         self, evcs: dict[str, dict], force=False, reason="disabled"
@@ -340,12 +393,21 @@ class INTManager:
             api.add_evcs_metadata(evcs, metadata, force),
         )
 
-    async def enable_int(self, evcs: dict[str, dict], force=False) -> None:
+    async def enable_int(
+        self,
+        evcs: dict[str, dict],
+        force=False,
+        proxy_port_enabled: Optional[bool] = None,
+        set_proxy_port_metadata=False,
+    ) -> None:
         """Enable INT on EVCs.
 
         evcs is a dict of prefetched EVCs from mef_eline based on evc_ids.
 
         The force bool option, if True, will bypass the following:
+        The proxy_port_enabled option, is to overwrite at the EVC level whether
+        or not proxy_port should be enabled for the EVC regardless of interface
+        proxy_port configuration
 
         1 - EVC already has INT
         2 - ProxyPort isn't UP
@@ -353,9 +415,18 @@ class INTManager:
 
         A proxy port is only used for an inter-EVC if it's been pre-configured,
         otherwise by default it's not expected to be in place.
+
+        Before enabling INT, like mef_eline, it'll remove the INT flows first.
         """
-        evcs = self._validate_map_enable_evcs(evcs, force)
-        log.info(f"Enabling INT on EVC ids: {list(evcs.keys())}, force: {force}")
+        evcs = self._validate_map_enable_evcs(evcs, force, proxy_port_enabled)
+        stored_flows = await api.get_stored_flows(
+            [utils.get_cookie(evc_id, settings.INT_COOKIE_PREFIX) for evc_id in evcs]
+        )
+        await self._remove_int_flows_by_cookies(stored_flows)
+        log.info(
+            f"Enabling INT on EVC ids: {list(evcs.keys())}, force: {force}, "
+            f"proxy_port_enabled: {proxy_port_enabled}"
+        )
 
         metadata = {
             "telemetry": {
@@ -365,6 +436,8 @@ class INTManager:
                 "status_updated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
             }
         }
+        if set_proxy_port_metadata:
+            metadata["proxy_port_enabled"] = proxy_port_enabled
         await self.install_int_flows(evcs, metadata)
         self._add_pps_evc_ids(evcs)
 
@@ -528,6 +601,17 @@ class INTManager:
         ):
             raise ProxyPortAsymmetric(
                 evc["id"], f"proxy ports asymmetry. pp_a: {pp_a}, pp_z: {pp_z}"
+            )
+
+        if (
+            not utils.is_intra_switch_evc(evc)
+            and utils.get_evc_proxy_port_value(evc)
+            and (not pp_a or not pp_z)
+        ):
+            raise ProxyPortRequired(
+                evc["id"],
+                "with proxy_port_enabled must have both proxy ports set, "
+                f"pp_a: {pp_a}, pp_z: {pp_z}",
             )
 
         if utils.is_intra_switch_evc(evc) and not pp_a and not pp_z:
@@ -724,6 +808,7 @@ class INTManager:
         self,
         evcs: dict[str, dict],
         force=False,
+        proxy_port_enabled: Optional[bool] = None,
     ) -> dict[str, dict]:
         """Validate map enabling EVCs.
 
@@ -758,6 +843,12 @@ class INTManager:
             except ProxyPortError:
                 raise
 
+            if (
+                not utils.is_intra_switch_evc(evc)
+                and not proxy_port_enabled
+                or utils.get_evc_proxy_port_value(evc) is False
+            ):
+                continue
             self._validate_proxy_ports_symmetry(evc)
             if not pp_a and not pp_z:
                 continue

--- a/openapi.yml
+++ b/openapi.yml
@@ -37,6 +37,9 @@ paths:
                   type: boolean
                   description: Force INT to get enabled again. It will enable even if the EVC already has INT or if a ProxyPort isn't UP.
                   default: false
+                proxy_port_enabled:
+                  type: boolean
+                  description: Overwrites whether or not a proxy_port is expected for an inter EVC.
       responses:
         '201':
           description: INT enabled on EVCs

--- a/tests/unit/test_flow_builder_inter_evc.py
+++ b/tests/unit/test_flow_builder_inter_evc.py
@@ -1,5 +1,7 @@
 """Test flow_builder."""
 
+import pytest
+
 from unittest.mock import MagicMock
 from napps.kytos.telemetry_int.managers.flow_builder import FlowBuilder
 from napps.kytos.telemetry_int.managers.int import INTManager
@@ -529,6 +531,132 @@ def test_build_int_flows_inter_evpl(
         assert (i, flow["flow"]) == (i, expected_flows[i]["flow"])
 
 
+def test_build_int_flows_inter_evpl_flows_count_evc_metadata_proxy_port_enabled(
+    evcs_data, inter_evc_evpl_set_queue_flows_data
+) -> None:
+    """Test build INT flows inter EVPL with proxy_port_enabled EVC metadata.
+
+               +----+                                              +----+
+              5|    |6                                            5|    |6
+           +---+----v---+            +------------+           +----+----v---+
+        1  |            |            |            |           |             |1
+    -------+            |3         2 |            |3        2 |             +-------
+     vlan  |     s1     +------------+    s2      +-----------+    s3       | vlan
+     101   |            |            |            |           |             | 102
+           |            |            |            |           |             |
+           +------------+            +------------+           +-------------+
+
+    """
+    controller = get_controller_mock()
+    int_manager = INTManager(controller)
+    get_proxy_port_or_raise = MagicMock()
+    int_manager.get_proxy_port_or_raise = get_proxy_port_or_raise
+
+    evc_id = "16a76ae61b2f46"
+    dpid_a = "00:00:00:00:00:00:00:01"
+    mock_switch_a = get_switch_mock(dpid_a, 0x04)
+    mock_interface_a1 = get_interface_mock("s1-eth1", 1, mock_switch_a)
+    mock_interface_a1.id = f"{dpid_a}:{mock_interface_a1.port_number}"
+    mock_interface_a5 = get_interface_mock("s1-eth5", 5, mock_switch_a)
+    mock_interface_a1.metadata = {"proxy_port": mock_interface_a5.port_number}
+    mock_interface_a5.status = EntityStatus.UP
+    mock_interface_a6 = get_interface_mock("s1-eth6", 6, mock_switch_a)
+    mock_interface_a6.status = EntityStatus.UP
+    mock_interface_a5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_a5.port_number,
+                mock_interface_a6.port_number,
+            ]
+        }
+    }
+
+    dpid_z = "00:00:00:00:00:00:00:03"
+    mock_switch_z = get_switch_mock(dpid_z, 0x04)
+    mock_interface_z1 = get_interface_mock("s1-eth1", 1, mock_switch_z)
+    mock_interface_z1.status = EntityStatus.UP
+    mock_interface_z1.id = f"{dpid_z}:{mock_interface_z1.port_number}"
+    mock_interface_z5 = get_interface_mock("s1-eth5", 5, mock_switch_z)
+    mock_interface_z1.metadata = {"proxy_port": mock_interface_z5.port_number}
+    mock_interface_z5.status = EntityStatus.UP
+    mock_interface_z6 = get_interface_mock("s1-eth6", 6, mock_switch_z)
+    mock_interface_z6.status = EntityStatus.UP
+    mock_interface_z5.metadata = {
+        "looped": {
+            "port_numbers": [
+                mock_interface_z5.port_number,
+                mock_interface_z6.port_number,
+            ]
+        }
+    }
+
+    mock_switch_a.get_interface_by_port_no = lambda port_no: {
+        mock_interface_a5.port_number: mock_interface_a5,
+        mock_interface_a6.port_number: mock_interface_a6,
+    }[port_no]
+
+    mock_switch_z.get_interface_by_port_no = lambda port_no: {
+        mock_interface_z5.port_number: mock_interface_z5,
+        mock_interface_z6.port_number: mock_interface_z6,
+    }[port_no]
+
+    pp_a = ProxyPort(source=mock_interface_a5)
+    assert pp_a.source == mock_interface_a5
+    assert pp_a.destination == mock_interface_a6
+    pp_z = ProxyPort(source=mock_interface_z5)
+    assert pp_z.source == mock_interface_z5
+    assert pp_z.destination == mock_interface_z6
+
+    get_proxy_port_or_raise.side_effect = [pp_a, pp_z]
+
+    # This will overwrite not to use proxy_port from the interface metadata
+    evcs_data[evc_id]["metadata"]["proxy_port_enabled"] = False
+
+    evcs_data = {evc_id: evcs_data[evc_id]}
+    evcs_data = int_manager._validate_map_enable_evcs(evcs_data)
+    stored_flows = _map_stored_flows_by_cookies(inter_evc_evpl_set_queue_flows_data)
+
+    cookie = get_cookie(evc_id, settings.MEF_COOKIE_PREFIX)
+    flows = FlowBuilder().build_int_flows(evcs_data, stored_flows)[cookie]
+
+    # This test case is only asserting expected flows numbers to avoid repetition,
+    # similar test cases already assert the expected flow contents
+
+    n_expected_source_flows, n_expected_hop_flows, n_expected_sink_flows = 3, 2, 3
+    assert (
+        len(flows)
+        == (n_expected_source_flows + n_expected_hop_flows + n_expected_sink_flows) * 2
+    )
+
+    # This will no longer overwrite, so the proxy_port flows will be built
+    evcs_data[evc_id]["metadata"].pop("proxy_port_enabled")
+    get_proxy_port_or_raise.side_effect = [pp_a, pp_z]
+
+    evcs_data = int_manager._validate_map_enable_evcs(evcs_data)
+    stored_flows = _map_stored_flows_by_cookies(inter_evc_evpl_set_queue_flows_data)
+    flows = FlowBuilder().build_int_flows(evcs_data, stored_flows)[cookie]
+
+    n_expected_source_flows, n_expected_hop_flows, n_expected_sink_flows = 3, 2, 4
+    assert (
+        len(flows)
+        == (n_expected_source_flows + n_expected_hop_flows + n_expected_sink_flows) * 2
+    )
+
+    # This will no longer overwrite too, so the proxy_port flows will be built
+    evcs_data[evc_id]["metadata"]["proxy_port_enabled"] = True
+    get_proxy_port_or_raise.side_effect = [pp_a, pp_z]
+
+    evcs_data = int_manager._validate_map_enable_evcs(evcs_data)
+    stored_flows = _map_stored_flows_by_cookies(inter_evc_evpl_set_queue_flows_data)
+    flows = FlowBuilder().build_int_flows(evcs_data, stored_flows)[cookie]
+
+    n_expected_source_flows, n_expected_hop_flows, n_expected_sink_flows = 3, 2, 4
+    assert (
+        len(flows)
+        == (n_expected_source_flows + n_expected_hop_flows + n_expected_sink_flows) * 2
+    )
+
+
 def test_build_int_flows_inter_evpl_no_proxy_ports(
     evcs_data, inter_evc_evpl_flows_data
 ) -> None:
@@ -943,3 +1071,50 @@ def test_build_int_flows_inter_evpl_no_proxy_ports(
 
     for i, flow in enumerate(flows):
         assert (i, flow["flow"]) == (i, expected_flows[i]["flow"])
+
+
+@pytest.mark.parametrize(
+    "evc,uni_key,expected_method",
+    [
+        ({"uni_a": {"proxy_port": 1}, "metadata": {}}, "uni_a", "proxy_flows"),
+        ({"uni_a": {}, "metadata": {}}, "uni_a", "no_proxy_flows"),
+        (
+            {"uni_a": {"proxy_port": 1}, "metadata": {"proxy_port_enabled": False}},
+            "uni_a",
+            "no_proxy_flows",
+        ),
+        (
+            {"uni_a": {"proxy_port": 1}, "metadata": {"proxy_port_enabled": True}},
+            "uni_a",
+            "proxy_flows",
+        ),
+        (
+            {"uni_a": {}, "metadata": {"proxy_port_enabled": True}},
+            "uni_a",
+            "proxy_flows",
+        ),
+        (
+            {"uni_a": {}, "metadata": {}},
+            "uni_a",
+            "no_proxy_flows",
+        ),
+    ],
+)
+def test_bulkd_inter_sink_flows_cases(evc, uni_key, expected_method) -> None:
+    """Test build_int_sink_flows for inter EVCs.
+
+    By default inter EVC build not flows without proxy, and proxy metadata
+    at the EVC level has higher precedence than derived proxy_port interface metadata
+    """
+    controller = get_controller_mock()
+    int_manager = INTManager(controller)
+    no_proxy_port_method, proxy_port_method = MagicMock(), MagicMock()
+    int_manager.flow_builder._build_int_sink_flows_no_proxy_port = no_proxy_port_method
+    int_manager.flow_builder._build_int_sink_flows_proxy_port = proxy_port_method
+    int_manager.flow_builder._build_int_sink_flows(uni_key, evc, {})
+    if expected_method == "proxy_flows":
+        assert proxy_port_method.call_count == 1
+        assert not no_proxy_port_method.call_count
+    else:
+        assert no_proxy_port_method.call_count == 1
+        assert not proxy_port_method.call_count

--- a/tests/unit/test_int_manager.py
+++ b/tests/unit/test_int_manager.py
@@ -412,7 +412,7 @@ class TestINTManager:
         )
 
         int_manager = INTManager(controller)
-        int_manager.remove_int_flows = AsyncMock()
+        int_manager._remove_int_flows_by_cookies = AsyncMock()
         evcs = {
             "3766c105686749": {
                 "active": True,
@@ -432,6 +432,7 @@ class TestINTManager:
         await int_manager.enable_int(evcs, False)
 
         assert stored_flows_mock.call_count == 1
+        assert int_manager._remove_int_flows_by_cookies.call_count == 1
         assert api_mock.add_evcs_metadata.call_count == 3
         args = api_mock.add_evcs_metadata.call_args[0]
         assert "telemetry" in args[1]
@@ -541,6 +542,14 @@ class TestINTManager:
         # symmetric case
         evc["uni_a"]["proxy_port"] = pp_a
         int_manager._validate_proxy_ports_symmetry(evc)
+
+        # cover ProxyPortRequired for inter EVC with metadata
+        evc["uni_a"].pop("proxy_port")
+        evc["uni_z"].pop("proxy_port")
+        evc["metadata"] = {"proxy_port_enabled": True}
+        with pytest.raises(exceptions.ProxyPortRequired) as exc:
+            int_manager._validate_proxy_ports_symmetry(evc)
+        assert "proxy_port_enabled" in str(exc)
 
     def test_validate_proxy_ports_symmetry_intra_evc(self) -> None:
         """Test _validate_proxy_ports_symmetry intra evc."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -47,14 +47,13 @@ class TestMain:
         enable_int_args = self.napp.int_manager.enable_int.call_args
         # evcs arg
         assert evc_id in enable_int_args[0][0]
-        # force arg, False by default
-        assert not enable_int_args[0][1]
+        # assert the other args
+        assert enable_int_args[1] == {
+            "force": False,
+            "proxy_port_enabled": None,
+            "set_proxy_port_metadata": True,
+        }
 
-        assert self.napp.int_manager._remove_int_flows_by_cookies.call_count == 1
-        assert response.status_code == 201
-        assert response.json() == [evc_id]
-
-        assert self.napp.int_manager._remove_int_flows_by_cookies.call_count == 1
         assert response.status_code == 201
         assert response.json() == [evc_id]
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -358,3 +358,46 @@ def test_set_priority_exc() -> None:
 def test_get_svlan_dpid_link(link, dpid, expected_vlan) -> None:
     """Test get_svlan_dpid_link."""
     assert utils.get_svlan_dpid_link(link, dpid) == expected_vlan
+
+
+@pytest.mark.parametrize(
+    "evc,proxy_port_enabled,expected",
+    [
+        ({"metadata": {}}, True, {"metadata": {"proxy_port_enabled": True}}),
+        (
+            {"metadata": {"other": "value"}},
+            False,
+            {"metadata": {"other": "value", "proxy_port_enabled": False}},
+        ),
+        (
+            {"metadata": {"proxy_port_enabled": True}},
+            False,
+            {"metadata": {"proxy_port_enabled": False}},
+        ),
+        ({}, True, {}),
+    ],
+)
+def test_set_proxy_port_value(evc, proxy_port_enabled, expected) -> None:
+    """Test set_proxy_port_value function."""
+    result = utils.set_proxy_port_value(evc, proxy_port_enabled)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "evc,expected",
+    [
+        ({"metadata": {"proxy_port_enabled": True}}, True),
+        ({"metadata": {"proxy_port_enabled": False}}, False),
+        ({"metadata": {"proxy_port_enabled": None}}, None),
+        ({"metadata": {}}, None),
+        ({}, None),
+        ({"metadata": {"other": "value"}}, None),
+        (None, None),
+        ("invalid", None),
+        ([], None),
+    ],
+)
+def test_get_evc_proxy_port_value(evc, expected) -> None:
+    """Test get_evc_proxy_port_value function."""
+    result = utils.get_evc_proxy_port_value(evc)
+    assert result == expected

--- a/ui/k-info-panel/show_telemetry_int_data.kytos
+++ b/ui/k-info-panel/show_telemetry_int_data.kytos
@@ -10,6 +10,8 @@
                         <k-button icon="truck-moving" title="Redeploy Selected" tooltip="Redeploy INT on selected EVCs" @click="redeploySelectedEVCs()"></k-button>
                     </k-button-group>
                     <k-checkbox title="Force" v-model:model="forceOption" :value="true"></k-checkbox>
+                    <k-dropdown class="compact-dropdown" title="Inter EVC Proxy Port Enabled: " :options="proxyPortOptions"
+                    v-model:value="proxyPortOption"></k-dropdown>
                 </k-accordion-item>
                 <!--
                     Sections/Tables:
@@ -25,13 +27,14 @@
                                     <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('id')">ID &nbsp;{{sortIdentifierList[0]}}</th>
                                     <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('name')">Name &nbsp;{{sortIdentifierList[1]}}</th>
                                     <th class="sortable-column" rowspan="2" colspan="1" @click="changeSortedColumn('active')">Active &nbsp;{{sortIdentifierList[2]}}</th>
-                                    <th rowspan="1" colspan="4">Telemetry</th>
+                                    <th rowspan="1" colspan="5">Telemetry</th>
                                 </tr>
                                 <tr>
                                     <th class="sortable-column" @click="changeSortedColumn('enabled')">Enabled &nbsp;{{sortIdentifierList[3]}}</th>
                                     <th class="sortable-column" @click="changeSortedColumn('status')">Status &nbsp;{{sortIdentifierList[4]}}</th>
                                     <th class="sortable-column" @click="changeSortedColumn('status_reason')">Status Reason &nbsp;{{sortIdentifierList[5]}}</th>
-                                    <th class="sortable-column" @click="changeSortedColumn('status_updated_at')">Status Updated At &nbsp;{{sortIdentifierList[6]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('proxy_port_enabled')">Proxy Port Enabled &nbsp;{{sortIdentifierList[6]}}</th>
+                                    <th class="sortable-column" @click="changeSortedColumn('status_updated_at')">Status Updated At &nbsp;{{sortIdentifierList[7]}}</th>
                                 </tr>
                                 <tr>
                                     <th>
@@ -57,6 +60,9 @@
                                     <th>
                                         <input v-model="EVCTextFilter[6][1]"></input>
                                     </th>
+                                    <th>
+                                        <input v-model="EVCTextFilter[7][1]"></input>
+                                    </th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -68,6 +74,7 @@
                                     <td>{{item.enabled}}</td>
                                     <td :class="statusColor(item)">{{item.status}}</td>
                                     <td>{{item.status_reason}}</td>
+                                    <td>{{item.proxy_port_enabled}}</td>
                                     <td>{{item.status_updated_at}}</td>
                                 </tr>
                             </tbody>
@@ -96,16 +103,18 @@
                     ["enabled", ""],
                     ["status", ""],
                     ["status_reason", ""],
+                    ["proxy_port_enabled", ""],
                     ["status_updated_at", ""]
                 ],
                 selectedEVCs: [],
                 forceOption: [],
                 sortedColumnName: ["", 0],
-                sortIdentifier: {id: 0, name: 1, active: 2, enabled: 3, status: 4, status_reason: 5, status_updated_at: 6},
+                sortIdentifier: {id: 0, name: 1, active: 2, enabled: 3, status: 4, status_reason: 5, proxy_port_enabled: 6, status_updated_at: 7},
                 sortSymbols: ["▲", "▼"],
-                sortIdentifierList: ["", "", "", "", "", "", ""],
+                sortIdentifierList: ["", "", "", "", "", "", "", ""],
                 showDelModal: false,
-                currentTableData: []
+                currentTableData: [],
+                proxyPortOption: null
             }
         },
         methods: {
@@ -147,6 +156,9 @@
                 let payload = {evc_ids: this.selectedEVCs}
                 if (this.forceOption[0]) {
                     payload["force"] = true
+                }
+                if (this.proxyPortOption !== null) {
+                    payload["proxy_port_enabled"] = this.proxyPortOption
                 }
                 let request = $.ajax({
                                 type:"POST",
@@ -280,6 +292,7 @@
                     EVC_Obj["active"] = EVC_Data[EVC].active
                     EVC_Obj["id"] = EVC_Data[EVC].id
                     EVC_Obj["name"] = EVC_Data[EVC].name
+                    EVC_Obj["proxy_port_enabled"] = EVC_Data[EVC].metadata.proxy_port_enabled != null ? EVC_Data[EVC].metadata.proxy_port_enabled : "N/A"
                     if (EVC_Data[EVC].metadata?.telemetry) {
                         EVC_Obj["enabled"] = EVC_Data[EVC].metadata.telemetry.enabled.toString()
                         EVC_Obj["status"] = EVC_Data[EVC].metadata.telemetry.status
@@ -312,7 +325,8 @@
                     let filtered_data = current_data.filter((EVC) => {
                         for (const tableColumn of this.EVCTextFilter) {
                             let separatedFilter = tableColumn[1].toString()
-                            let separatedProperty = EVC[tableColumn[0]].toString()
+                            let propertyValue = EVC[tableColumn[0]]
+                            let separatedProperty = (propertyValue != null) ? propertyValue.toString() : ""
                             if (!(separatedProperty.includes(separatedFilter) || separatedFilter.includes(separatedProperty))) {
                                 return false
                             }
@@ -344,6 +358,14 @@
                     }
                 }
                 return current_data
+            },
+            //Proxy port dropdown values
+            proxyPortOptions(){
+              return [
+                {value: null, description: "none", selected: true},
+                {value: true, description: "true"},
+                {value: false, description: "false"}
+              ];
             }
         },
         //Extracts data from localStorage (if available) when first mounted.
@@ -427,5 +449,12 @@
     .sortable-column:hover {
         color: #eee;
         background-color: #322c5d;
+    }
+    .compact-dropdown {
+        flex: 0 0 auto !important;
+        width: 15em !important;
+        max-width: 15em !important;
+        min-width: 15em !important;
+        overflow: hidden !important;
     }
 </style>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -91,6 +91,7 @@ module.exports = {
                 EVC_Obj["active"] = EVC_Data[EVC].active
                 EVC_Obj["id"] = EVC_Data[EVC].id
                 EVC_Obj["name"] = EVC_Data[EVC].name
+                EVC_Obj["proxy_port_enabled"] = EVC_Data[EVC].metadata.proxy_port_enabled != null ? EVC_Data[EVC].metadata.proxy_port_enabled : "N/A"
                 if (EVC_Data[EVC].metadata?.telemetry) {
                     EVC_Obj["enabled"] = EVC_Data[EVC].metadata.telemetry.enabled.toString()
                     EVC_Obj["status"] = EVC_Data[EVC].metadata.telemetry.status

--- a/utils.py
+++ b/utils.py
@@ -29,6 +29,24 @@ def has_int_enabled(evc: dict) -> bool:
     )
 
 
+def set_proxy_port_value(evc: dict, proxy_port_enabled: Optional[bool] = None) -> dict:
+    """Set proxy_port_enabled metadata value for an existing EVC."""
+    if not evc or not isinstance(evc, dict):
+        return evc
+    if "metadata" not in evc:
+        evc["metadata"] = {}
+    evc["metadata"]["proxy_port_enabled"] = proxy_port_enabled
+    return evc
+
+
+def get_evc_proxy_port_value(evc: dict) -> Optional[bool]:
+    """Get proxy_port_enabled from EVC metadata."""
+    try:
+        return evc["metadata"]["proxy_port_enabled"]
+    except (KeyError, TypeError):
+        return None
+
+
 def get_evc_unis(evc: dict) -> tuple[dict, dict]:
     """Parse evc for unis."""
     uni_a_split = evc["uni_a"]["interface_id"].split(":")


### PR DESCRIPTION
Closes #162 

This PR is on top of PR #161

### Summary

See updated changelog file

### Local Tests

Local tests using INT Lab (also using the UI):

- Checked the displayed `proxy_port_enabled` metadata value in the UI table (see the Proxy Port Enabled column)

<img width="1912" height="451" alt="20250807_204444" src="https://github.com/user-attachments/assets/3bd2029c-aa9d-4fe1-8feb-883cb71c8afb" />


- Tried to set `proxy_port_enabled: true` on inter EVCs without proxy ports, resulted in 409 as expected (see the UI console message below)

<img width="1913" height="793" alt="20250807_204501" src="https://github.com/user-attachments/assets/ea48d358-2638-4e4c-8261-a7d2f44d0772" />


- Set `proxy_port_enabled: false` on an inter EVC that was sharing a proxy port, SDN traced it to ensure that it wasn't using the proxy_port

<img width="1920" height="910" alt="20250807_204859" src="https://github.com/user-attachments/assets/62061b84-da38-4ff7-99bc-662f5fbb2770" />

Before: SDN trace cp (EVPL sharing the same port but without proxy_port_enabled):

```
❯ ./trace_evpl_3333.sh  
HTTP/1.1 200 OK
content-length: 369
content-type: application/json
date: Thu, 07 Aug 2025 23:48:31 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 16,
            "time": "2025-08-07 20:48:32.432686",
            "type": "starting",
            "vlan": 3333
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "port": 11,
            "time": "2025-08-07 20:48:32.432768",
            "type": "intermediary",
            "vlan": 2
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "out": {
                "port": 22,
                "vlan": 3333
            },
            "port": 26,
            "time": "2025-08-07 20:48:32.432801",
            "type": "last",
            "vlan": 2
        }
    ]
}
```

After: SDN trace cp (EVPL sharing the same port but with proxy_port_enabled: false):

```
❯ ./trace_evpl_3333.sh
HTTP/1.1 200 OK
content-length: 257
content-type: application/json
date: Thu, 07 Aug 2025 23:49:05 GMT
server: uvicorn

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 16,
            "time": "2025-08-07 20:49:05.329512",
            "type": "starting",
            "vlan": 3333
        },
        {
            "dpid": "00:00:00:00:00:00:00:06",
            "out": {
                "port": 22,
                "vlan": 3333
            },
            "port": 11,
            "time": "2025-08-07 20:49:05.329558",
            "type": "last",
            "vlan": 2
        }
    ]
}
```

### End-to-End Tests

N/A yet
