### PR TITLE
release: bumped 2025.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.2.0] - 2026-02-02
+***********************
+
 Fixed
 =====
 - Fixed ``get_id_from_cookie(cookie)`` utility function, now it handles EVC id with leading zeros correctly. This function is used in flow mod error handling and also in the ``GET v1/evc/compare`` endpoint

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "telemetry_int",
   "description": "Napp to deploy In-band Network Telemetry for EVCs",
-  "version": "2025.1.0",
+  "version": "2025.2.0",
   "napp_dependencies": ["amlight/noviflow", "kytos/mef_eline", "kytos/flow_manager"],
   "license": "MIT",
   "tags": ["INT"],


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos/issues/603

### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A (nightly tests passing)
