### PR TITLE
release 2025.2.2: fixed setting the correct metadata when handling potential errors when a proxy port metadata changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,15 @@ file.
 [UNRELEASED] - Under development
 ********************************
 
-[2025.2.1] - 2026-02-11
+[2025.2.2] - 2026-02-11
+***********************
+
+Fixed
+=====
+- Fixed setting the correct metadata when handling potential errors when a proxy port metadata changes
+
+
+[2025.2.1] - 2026-02-09
 ***********************
 
 Fixed

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "telemetry_int",
   "description": "Napp to deploy In-band Network Telemetry for EVCs",
-  "version": "2025.2.1",
+  "version": "2025.2.2",
   "napp_dependencies": ["amlight/noviflow", "kytos/mef_eline", "kytos/flow_manager"],
   "license": "MIT",
   "tags": ["INT"],

--- a/managers/int.py
+++ b/managers/int.py
@@ -283,8 +283,7 @@ class INTManager:
             affected_evcs = {
                 evc_id: evc
                 for evc_id, evc in evcs.items()
-                if pp
-                and evc_id in pp.evc_ids
+                if (pp and evc_id in pp.evc_ids)
                 or evc["uni_a"]["interface_id"] == intf.id
                 or evc["uni_z"]["interface_id"] == intf.id
             }
@@ -336,7 +335,7 @@ class INTManager:
                     }
                 }
                 try:
-                    await api.add_evcs_metadata(evcs, metadata)
+                    await api.add_evcs_metadata(affected_evcs, metadata)
                 except (RetryError, UnrecoverableError) as exc:
                     excs = str(exc)
                     if isinstance(exc, RetryError):


### PR DESCRIPTION
Closes #179 

### Summary

See updated changelog file 

### Local Tests

- Locally explored on INT lab
- Covered with unit tests

### End-to-End Tests

Will be covered in the future
