### PR TITLE
 Fix: fixed setting the correct metadata when handling potential errors when a proxy port metadata changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Fixed
 =====
 - Fixed ``inconsistent_action`` disable on POST /v1/evc/check_consistency
 - Fixed post proxy port table 0 flows priority to be higher similarly to the rest of table 0 INT flows
+- Fixed setting the correct metadata when handling potential errors when a proxy port metadata changes
 
 [2025.2.0] - 2026-02-02
 ***********************

--- a/managers/int.py
+++ b/managers/int.py
@@ -283,8 +283,7 @@ class INTManager:
             affected_evcs = {
                 evc_id: evc
                 for evc_id, evc in evcs.items()
-                if pp
-                and evc_id in pp.evc_ids
+                if (pp and evc_id in pp.evc_ids)
                 or evc["uni_a"]["interface_id"] == intf.id
                 or evc["uni_z"]["interface_id"] == intf.id
             }
@@ -336,7 +335,7 @@ class INTManager:
                     }
                 }
                 try:
-                    await api.add_evcs_metadata(evcs, metadata)
+                    await api.add_evcs_metadata(affected_evcs, metadata)
                 except (RetryError, UnrecoverableError) as exc:
                     excs = str(exc)
                     if isinstance(exc, RetryError):


### PR DESCRIPTION
Same as https://github.com/kytos-ng/telemetry_int/pull/180

Closes #179 

### Summary

See updated changelog file 

### Local Tests

- Locally explored on INT lab
- Covered with unit tests

### End-to-End Tests

Will be covered in the future
